### PR TITLE
Make SciQLop collaborative

### DIFF
--- a/SciQLop/backend/sciqlop_application.py
+++ b/SciQLop/backend/sciqlop_application.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple, Union, Any
 from SciQLop.backend.theming.loader import load_stylesheets, build_palette
 from qasync import QEventLoop, QApplication
 import asyncio
+import os
 import sys
 
 from httpx_ws import aconnect_ws
@@ -67,10 +68,11 @@ class _SciQLopEventLoop(QEventLoop):
 
     async def _start_provider(self):
         try:
-            # try to connect to the server
-            room_name = "my_room"
+            # try to connect to the collaboration server
+            room_name = "collaboration"
+            collaboration_url = os.environ.get("SCIQLOP_COLLAB_SERVER", "https://sciqlop.lpp.polytechnique.fr/cache")
             async with (
-                aconnect_ws(f"http://localhost:1234/{room_name}") as websocket,
+                aconnect_ws(f"{collaboration_url}/{room_name}") as websocket,
                     WebsocketProvider(shared_doc, HttpxWebsocket(websocket, room_name)),
                 ):
                     await self.app_close_event.wait()

--- a/SciQLop/backend/sciqlop_application.py
+++ b/SciQLop/backend/sciqlop_application.py
@@ -69,7 +69,7 @@ class _SciQLopEventLoop(QEventLoop):
     async def _start_provider(self):
         try:
             # try to connect to the collaboration server
-            room_name = "collaboration"
+            room_name = os.environ.get("SCIQLOP_COLLAB_ROOM", "global")
             collaboration_url = os.environ.get("SCIQLOP_COLLAB_SERVER", "https://sciqlop.lpp.polytechnique.fr/cache")
             async with (
                 aconnect_ws(f"{collaboration_url}/{room_name}") as websocket,

--- a/SciQLop/backend/unique_names.py
+++ b/SciQLop/backend/unique_names.py
@@ -1,7 +1,15 @@
+_all_names_ = set()
 _used_names_ = {}
 
 
 def make_simple_incr_name(base: str, sep: str = "") -> str:
-    index = _used_names_.get(base, 0)
-    _used_names_[base] = index + 1
-    return f'{base}{sep}{index}'
+    while True:
+        index = _used_names_.get(base, 0)
+        _used_names_[base] = index + 1
+        res = f'{base}{sep}{index}'
+        if res not in _all_names_:
+            return res
+
+
+def set_name(name: str) -> None:
+    _all_names_.add(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,31 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13"
 ]
-dependencies = ['SciQLopPlots==0.11.0', 'speasy>=1.5.1', 'qtconsole', 'tscat_gui==0.4.*', 'tscat==0.4.*', "humanize", 'platformdirs',
-    'seaborn', "scipy", "pyside6==6.8.2", "shiboken6==6.8.2", "PySide6-QtAds==4.3.1.3", "IPython", "ipykernel", "jupyterlab>=4,!=4.1.0",
-    "notebook", "ipympl", "qasync", "jinja2", "pyzstd", "PyGitHub", "numpy>=2.0.0"]
+dependencies = [
+    'SciQLopPlots==0.11.0',
+    'speasy>=1.5.1',
+    'qtconsole',
+    'tscat_gui==0.4.*',
+    'tscat==0.4.*',
+    "humanize",
+    'platformdirs',
+    'seaborn',
+    "scipy",
+    "pyside6==6.8.2",
+    "shiboken6==6.8.2",
+    "PySide6-QtAds==4.3.1.3",
+    "IPython",
+    "ipykernel",
+    "jupyterlab>=4,!=4.1.0",
+    "notebook",
+    "ipympl",
+    "qasync",
+    "jinja2",
+    "pyzstd",
+    "PyGitHub",
+    "numpy>=2.0.0",
+    "httpx_ws>=0.7.1,<0.8.0",
+    "pycrdt-websocket>=0.15.4,<0.16.0",
 [project.urls]
 homepage = "https://github.com/SciQLop/SciQLop"
 bug_tracker = "https://github.com/SciQLop/SciQLop/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ jinja2
 pyzstd
 PyGitHub
 numpy>=2.0.0
+httpx_ws>=0.7.1,<0.8.0
+pycrdt-websocket>=0.15.4,<0.16.0


### PR DESCRIPTION
This adds collaborative support to SciQLop using CRDTs.
~~To try it out, a web server must be running, such as [this one](https://github.com/davidbrochart/pyqt-crdt/blob/78c2e3864da80b9563e1cef6b674f749c253fc31/examples/server.py).~~
Once https://github.com/SciQLop/speasy_proxy/pull/12 is merged, SciQLop will connect to https://sciqlop.lpp.polytechnique.fr/cache/collaboration by default, but this will be configurable with the `SCIQLOP_COLLAB_SERVER` environment variable.