### PR TITLE
Add PyHC Actions for PHEP 3 compliance and environment compatibility

### DIFF
--- a/.github/workflows/pyhc-actions-phep3-compliance.yml
+++ b/.github/workflows/pyhc-actions-phep3-compliance.yml
@@ -1,0 +1,17 @@
+name: pyhc-actions-phep3-compliance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 1 1,4,7,10 *'  # Quarterly: Jan/Apr/Jul/Oct 1 at 15:00 UTC
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  phep3-compliance-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PHEP 3 Compliance Checker
+        uses: heliophysicsPy/pyhc-actions/phep3-compliance@v1

--- a/.github/workflows/pyhc-actions-pyhc-env-compat.yml
+++ b/.github/workflows/pyhc-actions-pyhc-env-compat.yml
@@ -1,0 +1,17 @@
+name: pyhc-actions-pyhc-env-compat
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 15 1 1,4,7,10 *'  # Quarterly: Jan/Apr/Jul/Oct 1 at 15:00 UTC
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pyhc-env-compat-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PyHC Environment Compatibility Checker
+        uses: heliophysicsPy/pyhc-actions/pyhc-env-compat@pyhc-env-extras


### PR DESCRIPTION
Hey guys, Shawn from PyHC here! 

Can I politely ask you to be guinea pigs for these two new GitHub [Actions](https://github.com/heliophysicsPy/pyhc-actions) I developed? 😁 I'm asking all the core packages first. The actions check for (1) compliance with [PHEP 3](https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md) and (2) compatibility with the [PyHC Environment](https://github.com/heliophysicsPy/pyhc-docker-environment). The idea is that they'll pass ✅ if there are no problems, but error/warn when problems arise. 

**E.g., you'll get a red ❌ if:**
- A change to your package would introduce a dependency conflict in the PyHC Environment
- You do not adopt a new Python version or core Scientific Python package version within 6 months of release

**You'll get ignorable warnings ⚠️ if:**
- You support older Python versions or core Scientific Python packages beyond the required SPEC 0 support window
- You put an upper-bound constraint on a core Scientific Python package
- An optional dependency inside an [extra] would introduce a dependency conflict in the PyHC Environment

If this goes well, I'd love to live in a future where all PyHC packages use these actions. I think it'd help keep everyone on the same page and be a huge win for interoperability!

## Summary

This PR adds two GitHub Actions workflows from [heliophysicsPy/pyhc-actions](https://github.com/heliophysicsPy/pyhc-actions):

### 1. PHEP 3 Compliance Checker
Validates that the package meets [PHEP 3](https://github.com/heliophysicsPy/standards/blob/main/pheps/phep-0003.md) requirements:
- Python version support (36-month support window)
- Core Scientific Python package version support (24-month support window)
- New version adoption within 6 months of release
- Warnings on upper-bound constraints and exact version pins (core Scientific Python packages only)

### 2. PyHC Environment Compatibility Checker
Detects dependency conflicts with the [PyHC Environment](https://github.com/heliophysicsPy/pyhc-docker-environment) to ensure the package can be installed alongside other PyHC packages:
- Errors when conflicts are detected in base package
- Warns when conflicts are detected in optional dependency extras

## Trigger Schedule
Both workflows run on:
- Push/PR to main branch
- Quarterly schedule (Jan 1, Apr 1, Jul 1, Oct 1 at 3pm UTC)
- Manual trigger via workflow_dispatch

## Notes
- I tested these actions on [pyhc-core](https://github.com/heliophysicsPy/pyhc-core) and that went well, so now I'm rolling them out to all core PyHC packages as the first real-world tests.
- The checks should only take a few seconds each to run, largely thanks to `uv` doing most the heavy lifting.

## Feedback
Please share any feedback about how I've implemented these! And let me know if you experience buggy behavior. I want these to be helpful and not cumbersome.