### PR TITLE
feat: replace empty panel PNG with product search overlay

### DIFF
--- a/SciQLop/components/plotting/ui/product_search_overlay.py
+++ b/SciQLop/components/plotting/ui/product_search_overlay.py
@@ -1,0 +1,174 @@
+from PySide6.QtCore import Signal, Qt, QModelIndex, QStringListModel, QTimer
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QListView, QLabel,
+    QSpacerItem, QSizePolicy, QFrame,
+)
+from SciQLopPlots import ProductsFlatFilterModel, ProductsModel, QueryParser, ProductsModelNodeType
+
+from SciQLop.core.mime import decode_mime
+from SciQLop.core.ui import Metrics
+from SciQLop.components import sciqlop_logging
+
+log = sciqlop_logging.getLogger(__name__)
+
+_MAX_RESULTS = 50
+_MIN_QUERY_LENGTH = 2
+_DEBOUNCE_MS = 150
+
+_MUTED = "color: palette(placeholder-text); background: transparent; border: none;"
+_DROP_ZONE_STYLE = (
+    "border: 3ex dashed palette(mid);"
+    "border-radius: 3ex;"
+    "background: transparent;"
+    "padding: 6ex;"
+    "font-size: 14ex;"
+)
+
+
+def _display_path(path_parts: list[str]) -> str:
+    """Strip internal tree prefixes (root, speasy) for human-readable display."""
+    if len(path_parts) >= 3 and path_parts[0] == "root":
+        path_parts = path_parts[2:]
+    return "/".join(path_parts)
+
+
+class ProductSearchOverlay(QWidget):
+    """Overlay shown on empty plot panels with a product search box."""
+
+    product_selected = Signal(list)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
+
+        self._filter_model = ProductsFlatFilterModel(ProductsModel.instance())
+        self._list_model = QStringListModel()
+        self._result_paths: list[list[str]] = []
+
+        self._debounce = QTimer(self)
+        self._debounce.setSingleShot(True)
+        self._debounce.setInterval(_DEBOUNCE_MS)
+        self._debounce.timeout.connect(self._run_query)
+
+        content_width = Metrics.em(60)
+        separator_width = Metrics.em(20)
+        result_height = Metrics.ex(20)
+        drop_height = Metrics.ex(8)
+
+        layout = QVBoxLayout(self)
+        layout.addSpacerItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
+
+        self._label = QLabel("Add a product to this panel")
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._label.setStyleSheet(_MUTED + "font-size: 16ex;")
+        layout.addWidget(self._label, 0, Qt.AlignmentFlag.AlignCenter)
+
+        self._search_box = QLineEdit()
+        self._search_box.setPlaceholderText("Search products (e.g. MMS FGM, ACE MAG B_gsm)\u2026")
+        self._search_box.setFixedWidth(content_width)
+        self._search_box.setStyleSheet("font-size: 14ex; padding: 1ex;")
+        self._search_box.setClearButtonEnabled(True)
+        layout.addWidget(self._search_box, 0, Qt.AlignmentFlag.AlignCenter)
+
+        self._result_list = QListView()
+        self._result_list.setModel(self._list_model)
+        self._result_list.setFixedWidth(content_width)
+        self._result_list.setMaximumHeight(result_height)
+        self._result_list.setVisible(False)
+        layout.addWidget(self._result_list, 0, Qt.AlignmentFlag.AlignCenter)
+
+        # --- "or" separator + drop zone (hidden when results are shown) ---
+        self._drop_section = QWidget()
+        drop_layout = QVBoxLayout(self._drop_section)
+        drop_layout.setContentsMargins(0, 0, 0, 0)
+
+        separator_layout = QHBoxLayout()
+        separator_layout.setContentsMargins(0, 0, 0, 0)
+        line_left = QFrame()
+        line_left.setFrameShape(QFrame.Shape.HLine)
+        line_left.setStyleSheet("color: palette(placeholder-text);")
+        line_left.setMaximumWidth(separator_width)
+        or_label = QLabel("or")
+        or_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        or_label.setStyleSheet(_MUTED)
+        line_right = QFrame()
+        line_right.setFrameShape(QFrame.Shape.HLine)
+        line_right.setStyleSheet("color: palette(placeholder-text);")
+        line_right.setMaximumWidth(separator_width)
+        separator_layout.addStretch()
+        separator_layout.addWidget(line_left)
+        separator_layout.addWidget(or_label)
+        separator_layout.addWidget(line_right)
+        separator_layout.addStretch()
+        drop_layout.addLayout(separator_layout)
+
+        drop_zone = QLabel("Drop products here")
+        drop_zone.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        drop_zone.setStyleSheet(_DROP_ZONE_STYLE)
+        drop_zone.setFixedWidth(content_width)
+        drop_zone.setMinimumHeight(drop_height)
+        drop_layout.addWidget(drop_zone, 0, Qt.AlignmentFlag.AlignCenter)
+
+        layout.addWidget(self._drop_section, 0, Qt.AlignmentFlag.AlignCenter)
+
+        layout.addSpacerItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
+
+        self._search_box.textChanged.connect(self._on_text_changed)
+        self._result_list.clicked.connect(self._on_result_clicked)
+        self._result_list.activated.connect(self._on_result_clicked)
+        self._filter_model.layoutChanged.connect(self._on_filter_ready)
+        self._filter_model.modelReset.connect(self._on_filter_ready)
+
+    def _show_results(self, show: bool):
+        self._result_list.setVisible(show)
+        self._drop_section.setVisible(not show)
+
+    def _on_text_changed(self, text: str):
+        if len(text.strip()) < _MIN_QUERY_LENGTH:
+            self._debounce.stop()
+            self._show_results(False)
+            self._result_paths.clear()
+            self._list_model.setStringList([])
+            return
+        self._debounce.start()
+
+    def _run_query(self):
+        text = self._search_box.text().strip()
+        if len(text) < _MIN_QUERY_LENGTH:
+            return
+        self._filter_model.set_query(QueryParser.parse(text))
+
+    def _on_filter_ready(self):
+        text = self._search_box.text().strip()
+        if len(text) < _MIN_QUERY_LENGTH:
+            return
+        count = min(self._filter_model.rowCount(), _MAX_RESULTS)
+        if count == 0:
+            self._show_results(False)
+            self._result_paths.clear()
+            self._list_model.setStringList([])
+            return
+        indices = [self._filter_model.index(i, 0) for i in range(count)]
+        mime = self._filter_model.mimeData(indices)
+        if mime is None:
+            return
+        products = decode_mime(mime)
+        if not products:
+            return
+        self._result_paths = products
+        self._list_model.setStringList([_display_path(p) for p in products])
+        self._show_results(True)
+
+    def _on_result_clicked(self, index: QModelIndex):
+        row = index.row()
+        if row < 0 or row >= len(self._result_paths):
+            return
+        product_path = self._result_paths[row]
+        node = ProductsModel.node(product_path)
+        if node is None or node.node_type() != ProductsModelNodeType.PARAMETER:
+            return
+        log.debug(f"Product selected from search overlay: {product_path}")
+        self.product_selected.emit(product_path)
+
+    def focus_search(self):
+        self._search_box.setFocus()

--- a/SciQLop/components/plotting/ui/time_sync_panel.py
+++ b/SciQLop/components/plotting/ui/time_sync_panel.py
@@ -17,6 +17,7 @@ from SciQLop.core.property import SciQLopProperty
 from SciQLop.core.mime import decode_mime
 from SciQLop.core.mime.types import PRODUCT_LIST_MIME_TYPE, TIME_RANGE_MIME_TYPE
 from SciQLop.components.plotting.backend.palette import Palette, make_color_list
+from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
 
 log = sciqlop_logging.getLogger(__name__)
 
@@ -184,6 +185,27 @@ class TimeSyncPanel(SciQLopMultiPlotPanel):
         self._catalog_manager = PanelCatalogManager(self)
         self.installEventFilter(self)
         self.plot_added.connect(self._install_filter_on_plot)
+
+        self._search_overlay = ProductSearchOverlay(self.viewport())
+        self._search_overlay.product_selected.connect(self._on_overlay_product_selected)
+        self.plot_added.connect(self._dismiss_search_overlay)
+        self._search_overlay.raise_()
+        self._search_overlay.focus_search()
+
+    def _on_overlay_product_selected(self, product_path: list[str]):
+        from SciQLopPlots import PlotType
+        plot_product(self, product_path, plot_type=PlotType.TimeSeries)
+
+    def _dismiss_search_overlay(self, _plot=None):
+        if self._search_overlay is not None:
+            self._search_overlay.hide()
+            self._search_overlay.deleteLater()
+            self._search_overlay = None
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self._search_overlay is not None:
+            self._search_overlay.setGeometry(self.viewport().geometry())
 
     def update_theme(self):
         from SciQLop.components.theming.palette import SCIQLOP_PALETTE

--- a/SciQLop/resources/stylesheets/SciQLopWidgets.qss.j2
+++ b/SciQLop/resources/stylesheets/SciQLopWidgets.qss.j2
@@ -79,7 +79,7 @@ SciQLopPlotContainer[empty=true] {
     margin: 0;
     border-top-width: 0;
     padding: 0;
-    border-image: url(:/plot_panel_dd_background.png) 0 0 0 0 stretch stretch;
+    border-image: none;
 }
 
 SciQLopPlotContainer::handle:vertical {

--- a/tests/test_product_search_overlay.py
+++ b/tests/test_product_search_overlay.py
@@ -1,0 +1,124 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+from PySide6.QtWidgets import QLineEdit, QListView, QLabel
+from SciQLopPlots import ProductsModelNodeType
+
+
+class TestProductSearchOverlayCreation:
+    def test_overlay_has_search_box(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+        line_edit = overlay.findChild(QLineEdit)
+        assert line_edit is not None
+        assert "Search products" in line_edit.placeholderText()
+
+    def test_overlay_has_result_list(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+        list_view = overlay.findChild(QListView)
+        assert list_view is not None
+        assert not list_view.isVisible()
+
+    def test_overlay_has_label(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+        labels = overlay.findChildren(QLabel)
+        texts = [l.text() for l in labels]
+        assert any("Add a product" in t for t in texts)
+
+    def test_overlay_has_drop_zone(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+        labels = overlay.findChildren(QLabel)
+        texts = [l.text() for l in labels]
+        assert any("Drop products here" in t for t in texts)
+
+
+class TestProductSearchOverlaySelection:
+    def test_clicking_parameter_emits_signal(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        import SciQLop.components.plotting.ui.product_search_overlay as overlay_mod
+
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+
+        signals = []
+        overlay.product_selected.connect(lambda p: signals.append(p))
+
+        mock_node = MagicMock()
+        mock_node.node_type.return_value = ProductsModelNodeType.PARAMETER
+        overlay._result_paths = [["amda", "MMS", "MMS1", "FGM", "mms1_b_gse"]]
+        mock_index = MagicMock()
+        mock_index.row.return_value = 0
+
+        with patch.object(overlay_mod, "ProductsModel") as mock_model:
+            mock_model.node.return_value = mock_node
+            overlay._on_result_clicked(mock_index)
+
+        assert len(signals) == 1
+        assert signals[0] == ["amda", "MMS", "MMS1", "FGM", "mms1_b_gse"]
+
+    def test_clicking_folder_does_not_emit(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        import SciQLop.components.plotting.ui.product_search_overlay as overlay_mod
+
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+
+        signals = []
+        overlay.product_selected.connect(lambda p: signals.append(p))
+
+        mock_node = MagicMock()
+        mock_node.node_type.return_value = ProductsModelNodeType.FOLDER
+        overlay._result_paths = [["amda", "MMS"]]
+        mock_index = MagicMock()
+        mock_index.row.return_value = 0
+
+        with patch.object(overlay_mod, "ProductsModel") as mock_model:
+            mock_model.node.return_value = mock_node
+            overlay._on_result_clicked(mock_index)
+
+        assert len(signals) == 0
+
+    def test_out_of_range_click_ignored(self, qtbot):
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        overlay = ProductSearchOverlay()
+        qtbot.addWidget(overlay)
+
+        signals = []
+        overlay.product_selected.connect(lambda p: signals.append(p))
+        overlay._result_paths = []
+        mock_index = MagicMock()
+        mock_index.row.return_value = 5
+
+        overlay._on_result_clicked(mock_index)
+        assert len(signals) == 0
+
+
+class TestTimeSyncPanelOverlay:
+    def test_new_panel_has_overlay(self, qtbot):
+        from SciQLop.components.plotting.ui.time_sync_panel import TimeSyncPanel
+        from SciQLop.components.plotting.ui.product_search_overlay import ProductSearchOverlay
+        panel = TimeSyncPanel(name="TestPanel")
+        qtbot.addWidget(panel)
+        panel.show()
+        assert panel._search_overlay is not None
+        assert isinstance(panel._search_overlay, ProductSearchOverlay)
+        assert panel._search_overlay.isVisible()
+
+    def test_overlay_hidden_after_plot_added(self, qtbot):
+        from SciQLop.components.plotting.ui.time_sync_panel import TimeSyncPanel
+        from SciQLopPlots import PlotType
+        panel = TimeSyncPanel(name="TestPanel2")
+        qtbot.addWidget(panel)
+        assert panel._search_overlay is not None
+
+        panel.create_plot(0, PlotType.TimeSeries)
+
+        qtbot.waitUntil(lambda: panel._search_overlay is None, timeout=1000)
+        assert panel._search_overlay is None


### PR DESCRIPTION
## Summary

- Replace the static "Drag and drop products here" PNG on empty panels with a live product search widget
- Search box with debounced fuzzy filtering via `ProductsFlatFilterModel` + `QueryParser`, showing full product paths
- Dashed "Drop products here" zone with "or" separator (file-upload page pattern)
- Drag-and-drop still works — overlay is parented to the viewport so DnD propagates naturally
- Overlay auto-dismisses when the first plot is added
- All sizing uses `Metrics.em()`/`ex()` for DPI portability

## Test plan

- [x] 9 unit/integration tests pass (`uv run pytest tests/test_product_search_overlay.py`)
- [x] Create a new panel → overlay appears with focused search box
- [x] Type a query (e.g. "mms fgm") → results appear after 2+ chars with full paths
- [x] Click a result → product plots, overlay disappears
- [x] Drag a product from the tree onto the panel → drop works, overlay disappears
- [x] Switch tabs while results are visible → no lag or panel detachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)