### PR TITLE
fix: UI cleanup — dock tabs, QSS, and runtime theme switching

### DIFF
--- a/SciQLop/components/theming/__init__.py
+++ b/SciQLop/components/theming/__init__.py
@@ -1,4 +1,4 @@
-from .icons import register_icon, get_icon, get_current_style_icon
+from .icons import register_icon, get_icon, get_current_style_icon, theme_icon, theme_adapted_icon
 from .stylesheet import load_stylesheets
 from .palette import setup_palette
 from .settings import SciQLopStyle

--- a/SciQLop/components/theming/icons.py
+++ b/SciQLop/components/theming/icons.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from PySide6.QtGui import QIcon, QColor, QPixmap, QPalette
-from PySide6.QtCore import QSize
+from PySide6.QtGui import QIcon, QIconEngine, QColor, QPixmap, QPainter, QPalette
+from PySide6.QtCore import QSize, QRect
 from SciQLopPlots import Icons
 from PySide6.QtWidgets import QApplication
 from SciQLop.components.storage import cache_dir
@@ -132,6 +132,41 @@ def _app_base_color() -> QColor:
     return QColor(255, 255, 255)
 
 
+class _ThemeIconEngine(QIconEngine):
+    """Resolves a named icon against the current palette on every paint call."""
+
+    def __init__(self, name: str, use_style_dir: bool):
+        super().__init__()
+        self._name = name
+        self._use_style_dir = use_style_dir
+
+    def _resolve(self) -> QIcon:
+        if self._use_style_dir:
+            from .settings import SciQLopStyle
+            path = per_palette_icon_dir(SciQLopStyle().color_palette) / f"{self._name}.png"
+            return QIcon(str(path))
+        return _mutate_icon_color(Icons.get_icon(self._name), opposite_color(_app_base_color()))
+
+    def paint(self, painter: QPainter, rect: QRect, mode, state):
+        self._resolve().paint(painter, rect, mode, state)
+
+    def pixmap(self, size: QSize, mode, state) -> QPixmap:
+        return self._resolve().pixmap(size, mode, state)
+
+    def clone(self) -> QIconEngine:
+        return _ThemeIconEngine(self._name, self._use_style_dir)
+
+
+def theme_icon(name: str) -> QIcon:
+    """Return an icon that automatically updates when the theme changes."""
+    return QIcon(_ThemeIconEngine(name, use_style_dir=True))
+
+
+def theme_adapted_icon(name: str) -> QIcon:
+    """Return a registry icon that auto-adapts its color to the current palette."""
+    return QIcon(_ThemeIconEngine(name, use_style_dir=False))
+
+
 def get_icon(name: str, auto_adapt_colors=True) -> QIcon:
     icon = Icons.get_icon(name)
     if auto_adapt_colors:
@@ -149,19 +184,16 @@ def build_icon_set_for_palette(palette_name: str, base_color: str or QColor):
     """Generates a variant of the default icon set with colors adapted to the given palette."""
     if type(base_color) is str:
         base_color = QColor(base_color)
-    icons = filter(_is_theme_icon, Icons.icons())
-    for icon in icons:
+    dest_color = opposite_color(base_color)
+    for icon in filter(_is_theme_icon, Icons.icons()):
         if '/' in icon:
             name = icon.split("/")[-1].split(".png")[0]
         else:
             name = icon.split(":")[-1].split(".png")[0]
-        destination_path = per_palette_icon_dir(palette_name) / f"{name}.png"
-        dest_color = opposite_color(base_color)
-        if not destination_path.exists():
-            mutated_icon = _mutate_icon_color(get_icon(icon, auto_adapt_colors=False), dest_color)
-            if 'theme' in name:
-                name = name.split("://icons/theme/")[-1].split(".png")[0]
-            mutated_icon.pixmap(QSize(24, 24)).save(str(per_palette_icon_dir(palette_name) / f"{name}.png"))
+        if 'theme' in name:
+            name = name.split("://icons/theme/")[-1].split(".png")[0]
+        mutated_icon = _mutate_icon_color(get_icon(icon, auto_adapt_colors=False), dest_color)
+        mutated_icon.pixmap(QSize(24, 24)).save(str(per_palette_icon_dir(palette_name) / f"{name}.png"))
 
 
 def list_icons() -> list[str]:

--- a/SciQLop/core/sciqlop_application.py
+++ b/SciQLop/core/sciqlop_application.py
@@ -30,6 +30,7 @@ _patch_qasync_infinite_timer()
 class SciQLopApp(QApplication):
     quickstart_shortcuts_added = QtCore.Signal(str)
     panels_list_changed = QtCore.Signal(list)
+    theme_changed = QtCore.Signal(str)
 
     def __init__(self, args):
         from SciQLop.components import sciqlop_logging
@@ -75,6 +76,7 @@ class SciQLopApp(QApplication):
         self.setPalette(self._current_palette)
         self.load_stylesheet()
         self._update_plot_themes()
+        self.theme_changed.emit(palette_name)
 
     def _update_plot_themes(self):
         from SciQLop.components.plotting.ui.time_sync_panel import TimeSyncPanel

--- a/SciQLop/core/ui/mainwindow.py
+++ b/SciQLop/core/ui/mainwindow.py
@@ -20,7 +20,7 @@ from SciQLop.core import TimeRange
 from SciQLop.core.sciqlop_application import sciqlop_app
 from SciQLop.core.unique_names import auto_name
 from SciQLop.components.workspaces import Workspace
-from SciQLop.components.theming import register_icon, get_icon, get_current_style_icon, SciQLopStyle
+from SciQLop.components.theming import register_icon, get_icon, get_current_style_icon, theme_icon, theme_adapted_icon, SciQLopStyle
 from SciQLop.core.ui import Metrics
 from SciQLop.components.sciqlop_logging import getLogger
 from SciQLopPlots import SciQLopMultiPlotPanel
@@ -91,6 +91,7 @@ class SciQLopMainWindow(QtWidgets.QMainWindow):
     def _setup_dock_manager(self):
         QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.FocusHighlighting, True)
         QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.FloatingContainerHasWidgetIcon, True)
+        QtAds.CDockManager.setConfigFlag(QtAds.CDockManager.TabCloseButtonIsToolButton, True)
         QtAds.CDockManager.setAutoHideConfigFlags(
             QtAds.CDockManager.AutoHideFeatureEnabled |
             QtAds.CDockManager.AutoHideCloseButtonCollapsesDock |
@@ -121,14 +122,14 @@ class SciQLopMainWindow(QtWidgets.QMainWindow):
 
     def _setup_side_panels(self):
         self.productTree = ProductsView(self)
-        self.productTree.setWindowIcon(get_current_style_icon("tree"))
+        self.productTree.setWindowIcon(theme_icon("tree"))
         self.add_side_pan(self.productTree)
 
         from SciQLop.components.products.product_context_menu import setup_product_context_menu
         setup_product_context_menu(self.productTree, self)
 
         self.catalogs_browser = CatalogBrowser(self)
-        self.catalogs_browser.setWindowIcon(get_current_style_icon("catalogue"))
+        self.catalogs_browser.setWindowIcon(theme_icon("catalogue"))
         self.add_side_pan(self.catalogs_browser)
         self.panel_added.connect(self.catalogs_browser.connect_to_panel)
 
@@ -141,16 +142,16 @@ class SciQLopMainWindow(QtWidgets.QMainWindow):
         self.toolsMenu.addAction("Open JupyterLab in browser", wm.open_in_browser)
 
         self.logs = LogsWidget(self)
-        self.logs.setWindowIcon(get_current_style_icon("view_list"))
-        self.add_side_pan(self.logs, QtAds.PySide6QtAds.ads.SideBarLocation.SideBarBottom)
+        self.logs.setWindowIcon(theme_icon("view_list"))
+        self.viewMenu.addAction("Logs", self._show_logs)
 
         self.settings_panel = SettingsPanel(self)
-        self.settings_panel.setWindowIcon(get_icon("settings"))
+        self.settings_panel.setWindowIcon(theme_adapted_icon("settings"))
         self.settings_panel.setWindowTitle("Settings")
         self.add_side_pan(self.settings_panel)
 
         self.properties_panel = PropertiesPanel(self)
-        self.properties_panel.setWindowIcon(get_icon("plot_properties"))
+        self.properties_panel.setWindowIcon(theme_adapted_icon("plot_properties"))
         self.add_side_pan(self.properties_panel)
 
     def _setup_toolbar(self):
@@ -161,12 +162,12 @@ class SciQLopMainWindow(QtWidgets.QMainWindow):
         self.addToolBar(QtCore.Qt.ToolBarArea.TopToolBarArea, self.toolBar)
 
         self.addTSPanel = QtGui.QAction(self)
-        self.addTSPanel.setIcon(get_current_style_icon("add_graph"))
+        self.addTSPanel.setIcon(theme_icon("add_graph"))
         self.addTSPanel.setText("Add new plot panel")
         self.addTSPanel.triggered.connect(lambda: self.new_plot_panel())
         self.toolBar.addAction(self.addTSPanel)
         sciqlop_app().add_quickstart_shortcut(name="Plot panel", description="Add a new plot panel",
-                                              icon=get_icon("plot_panel"), callback=self.new_plot_panel)
+                                              icon=theme_adapted_icon("plot_panel"), callback=self.new_plot_panel)
 
     def _setup_status_bar(self):
         self._statusbar = QtWidgets.QStatusBar(self)
@@ -229,6 +230,14 @@ class SciQLopMainWindow(QtWidgets.QMainWindow):
 
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(palette_settings.keybinding), self)
         shortcut.activated.connect(self._command_palette.toggle)
+
+    def _show_logs(self):
+        dw = self.dock_manager.findDockWidget(self.logs.windowTitle())
+        if dw is None:
+            self.addWidgetIntoDock(QtAds.DockWidgetArea.BottomDockWidgetArea, self.logs)
+        else:
+            dw.toggleView(True)
+            dw.raise_()
 
     def _show_appstore(self):
         if self._appstore is None:

--- a/SciQLop/core/web_channel_page.py
+++ b/SciQLop/core/web_channel_page.py
@@ -11,9 +11,6 @@ from PySide6.QtWidgets import QVBoxLayout, QWidget
 
 from jinja2 import Environment, FileSystemLoader
 
-from SciQLop.components.theming.palette import SCIQLOP_PALETTE
-
-
 class WebChannelPage(QWidget):
     """Base widget: renders a Jinja2 template in QWebEngineView with a QWebChannel backend.
 
@@ -39,20 +36,26 @@ class WebChannelPage(QWidget):
         self._view.settings().setAttribute(
             QWebEngineSettings.WebAttribute.LocalContentCanAccessFileUrls, True)
 
-        html = self._render_template()
-        # Strip .j2 suffix so the base URL matches the original non-template filename
-        base_name = self.template_name.removesuffix(".j2")
-        base_url = QUrl.fromLocalFile(os.path.join(self.resources_dir, base_name))
-        self._view.setHtml(html, base_url)
+        self._load_html()
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._view)
 
+        from SciQLop.core.sciqlop_application import sciqlop_app
+        sciqlop_app().theme_changed.connect(lambda _: self._load_html())
+
     def _create_backend(self) -> QObject:
         raise NotImplementedError
 
+    def _load_html(self):
+        html = self._render_template()
+        base_name = self.template_name.removesuffix(".j2")
+        base_url = QUrl.fromLocalFile(os.path.join(self.resources_dir, base_name))
+        self._view.setHtml(html, base_url)
+
     def _render_template(self) -> str:
+        from SciQLop.components.theming.palette import SCIQLOP_PALETTE
         env = Environment(loader=FileSystemLoader(self.resources_dir))
         template = env.get_template(self.template_name)
         return template.render(palette=SCIQLOP_PALETTE)

--- a/SciQLop/plugins/tscat_catalogs/catalogs.py
+++ b/SciQLop/plugins/tscat_catalogs/catalogs.py
@@ -6,14 +6,14 @@ from PySide6.QtWidgets import QToolBar
 from tscat_gui import TSCatGUI
 
 from SciQLop.core.ui.mainwindow import SciQLopMainWindow
-from SciQLop.components.theming import get_current_style_icon
+from SciQLop.components.theming import theme_icon
 
 
 class CatalogGUISpawner(QAction):
     def __init__(self, catalog_gui, parent=None):
         super(CatalogGUISpawner, self).__init__(parent)
         self.catalog_gui = catalog_gui
-        self.setIcon(get_current_style_icon("catalogue"))
+        self.setIcon(theme_icon("catalogue"))
         self.triggered.connect(self.show_catalogue_gui)
         self.setText("Open Catalogue Explorer")
 

--- a/SciQLop/resources/stylesheets/QWidgets/QComboBox.qss.j2
+++ b/SciQLop/resources/stylesheets/QWidgets/QComboBox.qss.j2
@@ -1,4 +1,5 @@
 
+QDateTimeEdit,
 QDateEdit,
 QComboBox {
   color: palette(text);
@@ -9,6 +10,7 @@ QComboBox {
   background-color: palette(button);
 }
 
+QDateTimeEdit:disabled,
 QDateEdit:disabled,
 QComboBox:disabled {
   color: {{ palette('UnselectedText') }};
@@ -16,6 +18,7 @@ QComboBox:disabled {
   border: 1px solid {{ palette('border') }};
 }
 
+QDateTimeEdit::drop-down,
 QDateEdit::drop-down,
 QComboBox::drop-down {
   border: none;
@@ -23,24 +26,28 @@ QComboBox::drop-down {
   width: 2ex;
 }
 
+QDateTimeEdit::down-arrow,
 QDateEdit::down-arrow,
 QComboBox::down-arrow {
   image: {{ icon('arrow_drop_down') }};
   margin-right: 1.2ex;
 }
 
+QDateTimeEdit::down-arrow:focus,
 QDateEdit::down-arrow:focus,
 QComboBox::down-arrow:focus {
   image: {{ icon('arrow_drop_down') }};
   margin-right: 1.2ex;
 }
 
+QDateTimeEdit::down-arrow:disabled,
 QDateEdit::down-arrow:disabled,
 QComboBox::down-arrow:disabled {
   image: {{ icon('arrow_drop_down') }};
   margin-right: 1.2ex;
 }
 
+QDateTimeEdit QAbstractItemView,
 QDateEdit QAbstractItemView,
 QComboBox QAbstractItemView {
   color: palette(text);
@@ -52,6 +59,7 @@ QComboBox QAbstractItemView {
   outline: none;
 }
 
+QDateTimeEdit QAbstractItemView::item,
 QDateEdit QAbstractItemView::item,
 QComboBox QAbstractItemView::item {
   color: palette(text);
@@ -59,12 +67,60 @@ QComboBox QAbstractItemView::item {
   padding: 0.4ex 0.6ex;
 }
 
+QDateTimeEdit QAbstractItemView::item:selected,
 QDateEdit QAbstractItemView::item:selected,
 QComboBox QAbstractItemView::item:selected {
   color: palette(highlighted-text);
   background-color: palette(highlight);
 }
 
+/* QCalendarWidget popup */
+QCalendarWidget {
+  background-color: palette(base);
+}
+
+QCalendarWidget QWidget#qt_calendar_navigationbar {
+  background-color: palette(button);
+  padding: 0.2ex;
+}
+
+QCalendarWidget QToolButton {
+  color: palette(text);
+  background-color: transparent;
+  border: none;
+  padding: 0.3ex 0.6ex;
+  border-radius: 0.3ex;
+}
+
+QCalendarWidget QToolButton:hover {
+  background-color: palette(mid);
+}
+
+QCalendarWidget QToolButton::menu-indicator {
+  image: none;
+  width: 0;
+}
+
+QCalendarWidget QTableView {
+  background-color: palette(base);
+  selection-background-color: palette(highlight);
+  selection-color: palette(highlighted-text);
+  alternate-background-color: palette(alternate-base);
+  outline: none;
+}
+
+QCalendarWidget QMenu {
+  color: palette(text);
+  background-color: palette(base);
+  border: 1px solid {{ palette('border') }};
+}
+
+QCalendarWidget QMenu::item:selected {
+  color: palette(highlighted-text);
+  background-color: palette(highlight);
+}
+
+QDateTimeEdit[frame='false'],
 QDateEdit[frame='false'],
 QComboBox[frame='false'] {
   color: palette(text);
@@ -72,6 +128,7 @@ QComboBox[frame='false'] {
   border: 1px solid transparent;
 }
 
+QDateTimeEdit[frame='false']:disabled,
 QDateEdit[frame='false']:disabled,
 QComboBox[frame='false']:disabled {
   color: {{ palette('UnselectedText') }};

--- a/SciQLop/resources/stylesheets/QtAds/QtAds.qss.j2
+++ b/SciQLop/resources/stylesheets/QtAds/QtAds.qss.j2
@@ -1,25 +1,40 @@
+/* Title-bar buttons: explicit size prevents macOS QMacStyle from inflating them */
 #tabsMenuButton {
     qproperty-icon: {{ icon('arrow_drop_down') }};
     qproperty-iconSize: 16px;
+    max-height: 2ex;
+    max-width: 2ex;
+    padding: 0;
+    margin: 0;
 }
 
 
 #dockAreaCloseButton {
     qproperty-icon: {{ icon('close') }}, {{ icon('close') }} disabled;
     qproperty-iconSize: 16px;
+    max-height: 2ex;
+    max-width: 2ex;
+    padding: 0;
+    margin: 0;
 }
 
 
 #detachGroupButton {
     qproperty-icon: {{ icon('detach_tab') }}, {{ icon('detach_tab') }} disabled;
     qproperty-iconSize: 16px;
+    max-height: 2ex;
+    max-width: 2ex;
+    padding: 0;
+    margin: 0;
 }
 
 #tabCloseButton {
-    margin-top: 0.2ex;
     background: none;
     border: none;
-    padding: 0 -0.2ex;
+    padding: 0;
+    margin: 0;
+    max-height: 2ex;
+    max-width: 2ex;
     qproperty-icon: {{ icon('close') }}, {{ icon('close') }} disabled;
     qproperty-iconSize: 16px;
 }


### PR DESCRIPTION
## Summary
- Move LogsWidget from always-visible bottom sidebar to on-demand **View > Logs** menu action
- Fix oversized dock tab headers on macOS by enabling `TabCloseButtonIsToolButton` (QPushButton → QToolButton) and constraining title-bar button dimensions in QSS
- Add `QDateTimeEdit` to QComboBox QSS selectors (QSS doesn't do class inheritance from QDateEdit)
- Style `QCalendarWidget` popup to match the application palette
- Fix runtime theme switching: icons now update live via `_ThemeIconEngine` (QIconEngine subclass), and WebEngine pages (welcome, appstore) re-render their Jinja2 templates on theme change
- Always regenerate per-palette icon PNGs instead of skipping when cached files exist

## Root causes

**macOS dock tab inflation:** With 2+ tabs, the active tab's close button (a `QPushButton` by default) gets ~32px minimum height from `QMacStyle`. With 1 tab the button is hidden, so the bar looks fine.

**QDateTimeEdit background mismatch:** `QDateEdit` was styled in `QComboBox.qss.j2` but QSS selectors don't match subclasses — `QDateTimeEdit` fell through to native rendering.

**Theme switching broken:** Icons were QIcon snapshots frozen at construction. `build_icon_set_for_palette` skipped regeneration when files existed on disk. WebEngine pages rendered HTML once at init with the palette dict captured at import time.

## Test plan
- [x] Verify View > Logs opens the log panel in the bottom dock area
- [x] Verify dock tab headers are compact on macOS 14" display
- [x] Verify QDateTimeEdit matches surrounding toolbar style
- [x] Verify calendar popup is themed
- [x] Switch theme at runtime — icons, stylesheets, and welcome/appstore pages all update
- [x] Verify no visual regression on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)