### PR TITLE
fix: validate package install before saving to workspace manifest

### DIFF
--- a/SciQLop/components/welcome/backend.py
+++ b/SciQLop/components/welcome/backend.py
@@ -87,6 +87,7 @@ class WelcomeBackend(QObject):
     appstore_requested = Signal()
     latest_release_ready = Signal(str)
     templates_changed = Signal()
+    dependency_install_finished = Signal(str)
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
@@ -309,14 +310,30 @@ class WelcomeBackend(QObject):
         manifest_path = os.path.join(workspace_dir, "workspace.sciqlop")
         manifest = WorkspaceManifest.load(manifest_path)
         new_deps = [d for d in deps if d not in manifest.requires]
-        if new_deps:
-            manifest.requires.extend(new_deps)
-            manifest.save(manifest_path)
+        if not new_deps:
+            return
+
+        active_dir = os.environ.get("SCIQLOP_WORKSPACE_DIR", "")
+        is_active = os.path.realpath(workspace_dir) == os.path.realpath(active_dir)
+
+        def _install():
             try:
-                cmd = uv_command("pip", "install", *new_deps)
-                subprocess.run(cmd, check=True)
+                if is_active:
+                    cmd = uv_command("pip", "install", *new_deps)
+                else:
+                    cmd = uv_command("pip", "install", "--dry-run", *new_deps)
+                subprocess.run(cmd, check=True, capture_output=True, text=True)
             except Exception as e:
                 log.error(f"Failed to install dependencies: {e}")
+                self.dependency_install_finished.emit(
+                    json.dumps({"ok": False, "deps": new_deps, "dir": workspace_dir, "error": str(e)}))
+                return
+            manifest.requires.extend(new_deps)
+            manifest.save(manifest_path)
+            self.dependency_install_finished.emit(
+                json.dumps({"ok": True, "deps": new_deps, "dir": workspace_dir}))
+
+        threading.Thread(target=_install, daemon=True).start()
 
     @Slot()
     def open_appstore(self) -> None:

--- a/SciQLop/components/welcome/resources/welcome.js
+++ b/SciQLop/components/welcome/resources/welcome.js
@@ -413,7 +413,7 @@ function showWorkspaceDetails(ws, isActive) {
             '<button class="primary" onclick="tryOpenWorkspace(\'' + escapeAttr(ws.directory) + '\')">Open workspace</button>' +
             '<div class="details-actions-row">' +
                 '<button class="secondary" onclick="backend.duplicate_workspace(\'' + escapeAttr(ws.directory) + '\')">Clone</button>' +
-                (ws.is_default ? '' :
+                (ws.is_default || isActive ? '' :
                     '<button class="secondary danger" onclick="confirmDelete(\'' + escapeAttr(ws.directory) + '\', \'' + escapeAttr(ws.name) + '\')">Delete</button>') +
             '</div>' +
         '</div>';

--- a/SciQLop/components/welcome/resources/welcome.js
+++ b/SciQLop/components/welcome/resources/welcome.js
@@ -1,5 +1,7 @@
 let backend = null;
 let selectedCard = null;
+let _currentDetailsWs = null;
+let _currentDetailsIsActive = false;
 
 // --- Initialization ---
 
@@ -22,6 +24,7 @@ function init() {
         backend.templates_changed.connect(loadTemplates);
         backend.latest_release_ready.connect(showLatestRelease);
         backend.featured_packages_ready.connect(onFeaturedReady);
+        backend.dependency_install_finished.connect(onDependencyInstallFinished);
         backend.fetch_latest_release();
         backend.fetch_featured_packages();
 
@@ -371,7 +374,19 @@ function createFeaturedCard(pkg) {
 
 // --- Details panel ---
 
+function onDependencyInstallFinished(resultJson) {
+    var result = JSON.parse(resultJson);
+    if (_currentDetailsWs && _currentDetailsWs.directory === result.dir) {
+        if (result.ok) {
+            _currentDetailsWs.requires = (_currentDetailsWs.requires || []).concat(result.deps);
+        }
+        showWorkspaceDetails(_currentDetailsWs, _currentDetailsIsActive);
+    }
+}
+
 function showWorkspaceDetails(ws, isActive) {
+    _currentDetailsWs = ws;
+    _currentDetailsIsActive = isActive;
     const panel = document.getElementById("details-panel");
     document.getElementById("details-title").textContent = "Workspace details";
 
@@ -469,15 +484,8 @@ function buildPackageList(ws, isActive, editable) {
             var doAdd = function() {
                 var dep = addInput.value.trim();
                 if (!dep) return;
-                ws.requires = (ws.requires || []).concat([dep]);
-                if (isActive) {
-                    backend.add_dependencies_to_workspace(
-                        ws.directory, JSON.stringify([dep]));
-                } else {
-                    backend.update_workspace_field(ws.directory,
-                        JSON.stringify({field: "requires", value: ws.requires}));
-                }
-                showWorkspaceDetails(ws, isActive);
+                backend.add_dependencies_to_workspace(
+                    ws.directory, JSON.stringify([dep]));
             };
             addBtn.addEventListener("click", doAdd);
             addInput.addEventListener("keydown", function(e) {

--- a/SciQLop/components/workspaces/backend/workspace.py
+++ b/SciQLop/components/workspaces/backend/workspace.py
@@ -1,11 +1,13 @@
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 from PySide6.QtCore import QObject, Signal
 
 from SciQLop.components.workspaces.backend.workspace_manifest import WorkspaceManifest
+from SciQLop.components.workspaces.backend.uv import uv_command
 from SciQLop.components.sciqlop_logging import getLogger
 
 log = getLogger(__name__)
@@ -44,12 +46,34 @@ class Workspace(QObject):
     def dependencies(self) -> list[str]:
         return self._manifest.requires
 
-    def install_dependency(self, dep: str):
-        if dep not in self._manifest.requires:
-            self._manifest.requires.append(dep)
-            self._manifest.save(self._manifest_path)
+    def _uv_install(self, packages: list[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(uv_command("pip", "install", *packages), capture_output=True, text=True)
 
-    def install_dependencies(self, deps: list[str]):
+    def install_dependency(self, dep: str) -> bool:
+        if dep in self._manifest.requires:
+            return True
+        result = self._uv_install([dep])
+        if result.returncode != 0:
+            log.error("Failed to install %s: %s", dep, result.stderr)
+            return False
+        self._manifest.requires.append(dep)
+        self._manifest.save(self._manifest_path)
+        return True
+
+    def install_dependencies(self, deps: list[str]) -> bool:
+        added = [d for d in deps if d not in self._manifest.requires]
+        if not added:
+            return True
+        result = self._uv_install(added)
+        if result.returncode != 0:
+            log.error("Failed to install %s: %s", added, result.stderr)
+            return False
+        self._manifest.requires.extend(added)
+        self._manifest.save(self._manifest_path)
+        return True
+
+    def record_dependencies(self, deps: list[str]):
+        """Save deps to manifest without installing (caller already installed)."""
         added = [d for d in deps if d not in self._manifest.requires]
         if added:
             self._manifest.requires.extend(added)

--- a/SciQLop/components/workspaces/backend/workspaces_manager.py
+++ b/SciQLop/components/workspaces/backend/workspaces_manager.py
@@ -157,6 +157,10 @@ class WorkspaceManager(QObject):
 
     @Slot(str)
     def delete_workspace(self, workspace: str):
+        active_dir = os.environ.get("SCIQLOP_WORKSPACE_DIR", "")
+        if os.path.realpath(workspace) == os.path.realpath(active_dir):
+            log.warning("Refusing to delete the active workspace: %s", workspace)
+            return
         shutil.rmtree(workspace, ignore_errors=True)
 
     @Slot(str)

--- a/SciQLop/sciqlop_app.py
+++ b/SciQLop/sciqlop_app.py
@@ -35,8 +35,9 @@ def switch_workspace(workspace_name: str) -> None:
     (from SCIQLOP_WORKSPACE_DIR env var), then exits with code 65 so the
     launcher restarts into the target workspace.
     """
-    ws_dir = os.environ.get("SCIQLOP_WORKSPACE_DIR", ".")
-    (Path(ws_dir) / SWITCH_WORKSPACE_FILE).write_text(workspace_name)
+    ws_dir = Path(os.environ.get("SCIQLOP_WORKSPACE_DIR", "."))
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    (ws_dir / SWITCH_WORKSPACE_FILE).write_text(workspace_name)
     from PySide6.QtWidgets import QApplication
     app = QApplication.instance()
     app._sciqlop_exit_code = EXIT_SWITCH_WORKSPACE

--- a/SciQLop/user_api/magics/install_magic.py
+++ b/SciQLop/user_api/magics/install_magic.py
@@ -18,7 +18,7 @@ def _record_in_manifest(packages: list[str]):
     ws = wm.workspace
     if ws is None:
         return
-    ws.install_dependencies(packages)
+    ws.record_dependencies(packages)
 
 
 def install_magic(line: str):


### PR DESCRIPTION
## Summary
- **Welcome page "Add" button**: install (active workspace) or dry-run resolve (inactive) before persisting to manifest. Runs in background thread to avoid UI freeze. UI updates only on success via new `dependency_install_finished` signal.
- **Workspace.install_dependency/install_dependencies**: now actually run `uv pip install` and only save on success.
- **%install magic**: uses new `record_dependencies()` since it already validates install itself.
- **delete_workspace**: refuses to delete the currently active workspace.
- **switch_workspace**: ensures workspace dir exists before writing switch target file.

## Test plan
- [x] Add a valid package (e.g. `numba`) to active workspace via welcome page — should install and appear in list
- [x] Add a nonexistent package (e.g. `lksdlkfds`) — should not appear in manifest or UI
- [x] Add a package to an inactive workspace — should dry-run validate before saving
- [x] Try deleting the active workspace — should be refused
- [x] Switch workspaces after deleting a workspace directory — should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)