### PR TITLE
fix: validate PE binaries in Windows bundle

### DIFF
--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -132,4 +132,24 @@ Get-ChildItem -Path $PackageDir -Recurse |
     Where-Object { $_.Attributes -band [IO.FileAttributes]::ReparsePoint } |
     Remove-Item -Force
 
+########################################
+# Validate PE binaries
+########################################
+
+Write-Host "Validating PE binaries..."
+$InvalidBinaries = @()
+Get-ChildItem -Path $PackageDir -Recurse -Include *.exe,*.dll,*.pyd |
+    ForEach-Object {
+        $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+        if ($bytes.Length -lt 2 -or $bytes[0] -ne 0x4D -or $bytes[1] -ne 0x5A) {
+            $InvalidBinaries += $_.FullName
+            Write-Warning "Invalid PE: $($_.FullName)"
+        }
+    }
+if ($InvalidBinaries.Count -gt 0) {
+    Write-Error "Found $($InvalidBinaries.Count) invalid PE binary(ies) in the bundle"
+    exit 1
+}
+Write-Host "All PE binaries valid."
+
 Write-Host "Bundle complete at $PackageDir"


### PR DESCRIPTION
## Summary
- Adds a post-trim validation pass in `bundle.ps1` that checks every `.exe`/`.dll`/`.pyd` for MZ magic bytes
- Fails the build early with a list of offending files instead of getting a cryptic `0x800700C1` from the Windows Store signing pipeline

## Context
Windows Store submission fails with `0x800700C1` ("not a valid Win32 application") when non-PE binaries (e.g., ELF files from python-build-standalone, Unix shell scripts from Node.js) end up in the MSIX package.

## Test plan
- [ ] Run `bundle.ps1` on Windows CI and verify validation passes on a clean bundle
- [ ] Intentionally drop a non-PE file with `.dll` extension into the package dir and verify the build fails with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)