### PR TITLE
fix: appstore picks wrong plugin version

### DIFF
--- a/SciQLop/components/appstore/backend.py
+++ b/SciQLop/components/appstore/backend.py
@@ -7,6 +7,8 @@ import threading
 import urllib.request
 from importlib.metadata import PackageNotFoundError, distribution
 
+import packaging.version
+
 from PySide6.QtCore import QObject, Signal, Slot
 
 from SciQLop.components.sciqlop_logging import getLogger
@@ -27,7 +29,9 @@ def _fetch_index(url: str) -> list[dict]:
 
 def _latest_version(plugin: dict) -> dict | None:
     versions = plugin.get("versions", [])
-    return versions[-1] if versions else None
+    if not versions:
+        return None
+    return max(versions, key=lambda v: packaging.version.parse(v["version"]))
 
 
 def _package_name_from_pip(pip_field: str) -> str | None:


### PR DESCRIPTION
## Summary
- `_latest_version()` used `versions[-1]` assuming ascending order, but the appstore index lists versions newest-first
- For CDF Workbench, this returned `0.2.0` instead of `0.3.0`
- Now uses `max()` with `packaging.version.parse` so it's order-independent

## Test plan
- [ ] Open appstore, verify CDF Workbench shows 0.3.0 as the installable version
- [ ] Install a plugin from the appstore and confirm the latest version is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)