### PR TITLE
fix: remove Unix artifacts from MSIX bundle for Store compliance

### DIFF
--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -132,4 +132,43 @@ Get-ChildItem -Path $PackageDir -Recurse |
     Where-Object { $_.Attributes -band [IO.FileAttributes]::ReparsePoint } |
     Remove-Item -Force
 
+# Remove Unix artifacts that trip the Windows Store pre-processing scanner (0x800700C1)
+Get-ChildItem -Path $PackageDir -Recurse -Include *.a,*.o,*.so,*.dylib |
+    Remove-Item -Force
+# Node.js ships extensionless Unix shell scripts alongside .cmd wrappers
+foreach ($dir in @("$PackageDir\node", "$PackageDir\node\node_modules")) {
+    if (Test-Path $dir) {
+        Get-ChildItem -Path $dir -Recurse -File |
+            Where-Object { -not $_.Extension } |
+            Where-Object {
+                $first = Get-Content $_.FullName -First 1 -ErrorAction SilentlyContinue
+                $first -and $first.StartsWith("#!")
+            } |
+            ForEach-Object {
+                Write-Host "Removing Unix shell script: $($_.FullName)"
+                Remove-Item $_.FullName -Force
+            }
+    }
+}
+
+########################################
+# Validate PE binaries
+########################################
+
+Write-Host "Validating PE binaries..."
+$InvalidBinaries = @()
+Get-ChildItem -Path $PackageDir -Recurse -Include *.exe,*.dll,*.pyd |
+    ForEach-Object {
+        $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+        if ($bytes.Length -lt 2 -or $bytes[0] -ne 0x4D -or $bytes[1] -ne 0x5A) {
+            $InvalidBinaries += $_.FullName
+            Write-Warning "Invalid PE: $($_.FullName)"
+        }
+    }
+if ($InvalidBinaries.Count -gt 0) {
+    Write-Error "Found $($InvalidBinaries.Count) invalid PE binary(ies) in the bundle"
+    exit 1
+}
+Write-Host "All PE binaries valid."
+
 Write-Host "Bundle complete at $PackageDir"


### PR DESCRIPTION
## Summary
- Windows Store pre-processing rejects the MSIX with `0x800700C1` ("not a valid Win32 application")
- The bundle contains Unix artifacts that the Store scanner considers invalid executables:
  - `.a`, `.o`, `.so`, `.dylib` files from Python/Node build artifacts
  - Extensionless shebang scripts from Node.js (`npm`, `npx`, `corepack`, etc.)
- Adds cleanup of these files after trimming, plus a PE validation pass (`MZ` magic check) to fail builds early

## Context
This supersedes #95 which only had the PE validation. This PR adds the actual artifact removal that should fix the Store submission.

## Test plan
- [ ] CI builds the MSIX successfully
- [ ] Submit the resulting MSIX to Partner Center and verify pre-processing passes
- [ ] Verify SciQLop still launches from the installed MSIX (Node.js `.cmd` wrappers are preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)