### PR TITLE
ci: sign macOS DMGs on pushes to main

### DIFF
--- a/.github/workflows/SingleExe.yml
+++ b/.github/workflows/SingleExe.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           echo "RELEASE=1" >> $GITHUB_ENV
       - name: Install signing certificate
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -52,7 +52,7 @@ jobs:
           rm certificate.p12
       - name: bundle SciQLop
         env:
-          CODESIGN_IDENTITY: ${{ github.event_name == 'release' && secrets.CODESIGN_IDENTITY || '' }}
+          CODESIGN_IDENTITY: ${{ (github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && secrets.CODESIGN_IDENTITY || '' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PWD: ${{ secrets.APPLE_ID_PWD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo "RELEASE=1" >> $GITHUB_ENV
       - name: Install signing certificate
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -96,7 +96,7 @@ jobs:
           rm certificate.p12
       - name: bundle SciQLop
         env:
-          CODESIGN_IDENTITY: ${{ github.event_name == 'release' && secrets.CODESIGN_IDENTITY || '' }}
+          CODESIGN_IDENTITY: ${{ (github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && secrets.CODESIGN_IDENTITY || '' }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PWD: ${{ secrets.APPLE_ID_PWD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
## Summary
- Extend the signing gate from `github.event_name == 'release'` to also include pushes to `main`
- Applies to both `build_arm64_dmg` and `build_x86_64_dmg` jobs (cert install step + `CODESIGN_IDENTITY` env var)

## Motivation
Waiting for a release to discover that signing is broken is painful -- the 6-hour `codesign --deep` hang (#98) only showed up at release time. Running the signed + notarized pipeline on every main push catches regressions continuously.

## Note
- PR builds still use ad-hoc signing (no cert, no notarization) to avoid exposing secrets to forks and to keep PR feedback fast
- `APPLE_ID` / `APPLE_ID_PWD` / `APPLE_TEAM_ID` were already passed unconditionally; notarization in `make_dmg.sh` already gated on the Apple ID envs being set, so it just starts working once `CODESIGN_IDENTITY` is also provided

## Test plan
- [ ] Merge #98 first so signing actually completes
- [ ] Push to main and verify both macOS jobs sign + notarize successfully
- [ ] Verify PR builds still run without touching signing/notarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)