### PR TITLE
fix(catalogs): panel overlay sync on delete + nested cocat sub-paths

### DIFF
--- a/SciQLop/components/catalogs/backend/panel_manager.py
+++ b/SciQLop/components/catalogs/backend/panel_manager.py
@@ -31,6 +31,13 @@ class PanelCatalogManager(QObject):
         self._mode = InteractionMode.VIEW
         self._bar_connected = False
         self._panel.span_created.connect(self._on_span_created)
+        registry = CatalogRegistry.instance()
+        for provider in registry.providers():
+            self._bind_provider(provider)
+        registry.provider_registered.connect(self._bind_provider)
+
+    def _bind_provider(self, provider) -> None:
+        provider.catalog_removed.connect(self.remove_catalog)
 
     @property
     def panel(self):

--- a/SciQLop/components/catalogs/ui/catalog_tree.py
+++ b/SciQLop/components/catalogs/ui/catalog_tree.py
@@ -283,7 +283,7 @@ class CatalogTreeModel(QAbstractItemModel):
                 self.endInsertRows()
                 target = folder
                 target_index = self.createIndex(folder.row(), 0, folder)
-                self._ensure_placeholders(folder, target_index)
+        self._ensure_placeholders(target, target_index)
 
     def _on_folder_removed(self, provider: CatalogProvider, pnode: _Node, path: list) -> None:
         target = pnode

--- a/SciQLop/plugins/collaborative_catalogs/cocat_provider.py
+++ b/SciQLop/plugins/collaborative_catalogs/cocat_provider.py
@@ -20,6 +20,21 @@ from SciQLop.components.sciqlop_logging import getLogger
 
 log = getLogger(__name__)
 
+_SUBPATH_ATTR = "sciqlop_path"
+
+
+def _encode_subpath(segments: list[str]) -> str:
+    return "/".join(segments)
+
+
+def _decode_subpath(value) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [s for s in value.split("/") if s]
+    return [str(s) for s in value if s]
+
+
 __here__ = os.path.dirname(__file__)
 register_icon("link", lambda: QIcon(os.path.join(__here__, "..", "..", "resources", "icons", "link.png")))
 register_icon("link_off", lambda: QIcon(os.path.join(__here__, "..", "..", "resources", "icons", "link_off.png")))
@@ -146,12 +161,16 @@ class CocatCatalogProvider(CatalogProvider):
             return
         self._rooms[room_id] = room
         self._load_room_catalogs(room_id, room)
+        # Re-emit folder_added now that CREATE_CATALOGS is in capabilities,
+        # so the tree can add "New Catalog..."/"New Folder..." placeholders
+        # that were skipped when the folder was first announced.
+        self.folder_added.emit([room_id])
         log.info("Joined room '%s', loaded %d catalogs", room_id,
-                 sum(1 for c in self._catalog_map.values() if c.path == [room_id]))
+                 sum(1 for c in self._catalog_map.values() if c.path and c.path[0] == room_id))
 
     def _detach_room_catalogs(self, room_id: str) -> None:
         """Remove catalogs from a room (sync, no WebSocket close)."""
-        catalogs_to_remove = [c for c in self._catalog_map.values() if c.path == [room_id]]
+        catalogs_to_remove = [c for c in self._catalog_map.values() if c.path and c.path[0] == room_id]
         for cat in catalogs_to_remove:
             self._catalog_map.pop(cat.uuid, None)
             super().remove_catalog(cat)
@@ -167,11 +186,12 @@ class CocatCatalogProvider(CatalogProvider):
     def _load_room_catalogs(self, room_id: str, room) -> None:
         for cat_name in room.catalogues:
             cocat_cat = room.get_catalogue(cat_name)
+            sub_path = _decode_subpath(cocat_cat.attributes.get(_SUBPATH_ATTR))
             cat = Catalog(
                 uuid=str(cocat_cat.uuid) if hasattr(cocat_cat, 'uuid') else cat_name,
                 name=cat_name,
                 provider=self,
-                path=[room_id],
+                path=[room_id, *sub_path],
             )
             self._catalog_map[cat.uuid] = cat
             events = [CocatEvent(ev, parent=self) for ev in cocat_cat.events]
@@ -234,13 +254,17 @@ class CocatCatalogProvider(CatalogProvider):
             room_id = next(iter(self._rooms), None)
         if room_id is None:
             raise RuntimeError("No rooms joined")
+        sub_path = list(path[1:]) if path else []
         room = self._rooms[room_id]
-        cocat_cat = room.db.create_catalogue(name=name, author="SciQLop")
+        attributes = {_SUBPATH_ATTR: _encode_subpath(sub_path)} if sub_path else None
+        cocat_cat = room.db.create_catalogue(
+            name=name, author="SciQLop", attributes=attributes,
+        )
         cat = Catalog(
             uuid=str(cocat_cat.uuid),
             name=name,
             provider=self,
-            path=[room_id],
+            path=[room_id, *sub_path],
         )
         self._catalog_map[cat.uuid] = cat
         self._set_events(cat, [])

--- a/SciQLop/user_api/catalogs/_service.py
+++ b/SciQLop/user_api/catalogs/_service.py
@@ -17,9 +17,16 @@ _UUID_KEY = "__sciqlop_uuid__"
 
 
 def _split_segments(path: str) -> list[str]:
-    if "//" in path:
-        return path.split("//")
-    return path.split("/")
+    segments = path.split("//")
+    for seg in segments:
+        if "/" in seg:
+            raise ValueError(
+                f"Invalid path {path!r}: segments must be separated by '//', "
+                f"and segments cannot contain '/' (got {seg!r})"
+            )
+        if not seg:
+            raise ValueError(f"Invalid path {path!r}: empty segment")
+    return segments
 
 
 def _parse_path(path: str) -> tuple[str, list[str], str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "shiboken6==6.10.2",
     "PySide6-QtAds==4.5.0.2",
     "ipython",
-    "jupyqt>=0.5.0",
+    "jupyqt>=0.5.2",
     "matplotlib==3.10.8",
     "qasync",
     "jinja2",

--- a/tests/test_catalog_provider.py
+++ b/tests/test_catalog_provider.py
@@ -405,6 +405,55 @@ def test_tree_model_dynamic_add_with_path(qtbot, qapp):
     assert model.data(cat_idx) == "New Cat"
 
 
+def test_tree_model_placeholders_added_on_late_folder_event(qtbot, qapp):
+    """A provider that gains CREATE_CATALOGS *after* the folder is announced
+    (cocat pattern: rooms exist before any is joined) must get placeholders
+    when folder_added is re-emitted. Regression for cocat UI bug where rooms
+    never received 'New Catalog...' / 'New Folder...' items."""
+    from SciQLop.components.catalogs.ui.catalog_tree import CatalogTreeModel, _PlaceholderType
+    from SciQLop.components.catalogs.backend.provider import CatalogProvider, Capability
+
+    class LateCapsProvider(CatalogProvider):
+        def __init__(self):
+            self._can_create = False
+            super().__init__(name="LateCaps")
+
+        def catalogs(self):
+            return []
+
+        def capabilities(self, catalog=None):
+            return {Capability.CREATE_CATALOGS} if self._can_create else set()
+
+    provider = LateCapsProvider()
+    model = CatalogTreeModel()
+
+    provider_idx = None
+    for i in range(model.rowCount()):
+        idx = model.index(i, 0)
+        if model.node_from_index(idx).provider is provider:
+            provider_idx = idx
+            break
+    assert provider_idx is not None
+
+    # Step 1: announce a folder while caps are still empty — no placeholders.
+    provider.folder_added.emit(["room1"])
+    assert model.rowCount(provider_idx) == 1
+    room_idx = model.index(0, 0, provider_idx)
+    assert model.rowCount(room_idx) == 0
+
+    # Step 2: flip capabilities (room joined) and re-emit folder_added.
+    provider._can_create = True
+    provider.folder_added.emit(["room1"])
+
+    # Room folder should now expose both placeholders.
+    placeholder_types = {
+        model.node_from_index(model.index(i, 0, room_idx)).placeholder_type
+        for i in range(model.rowCount(room_idx))
+    }
+    assert _PlaceholderType.CATALOG in placeholder_types
+    assert _PlaceholderType.FOLDER in placeholder_types
+
+
 def test_catalog_tree_model_dynamic_add(qtbot, qapp):
     """Test that creating a provider after the model populates the tree."""
     from SciQLop.components.catalogs.ui.catalog_tree import CatalogTreeModel
@@ -788,6 +837,99 @@ def test_cocat_provider_is_catalog_provider(qtbot, qapp):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     assert issubclass(mod.CocatCatalogProvider, CatalogProvider)
+
+
+def _load_cocat_provider_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "cocat_provider_under_test",
+        "SciQLop/plugins/collaborative_catalogs/cocat_provider.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeCatalogue:
+    def __init__(self, name, attributes=None):
+        self.uuid = f"uuid-{name}"
+        self.name = name
+        self.attributes = dict(attributes or {})
+        self.events = []
+
+
+class _FakeRoomDB:
+    def __init__(self):
+        self._catalogues: dict[str, _FakeCatalogue] = {}
+
+    def create_catalogue(self, name, author, attributes=None):
+        cat = _FakeCatalogue(name, attributes)
+        self._catalogues[name] = cat
+        return cat
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.db = _FakeRoomDB()
+
+    @property
+    def catalogues(self):
+        return list(self.db._catalogues.keys())
+
+    def get_catalogue(self, name_or_uuid):
+        for c in self.db._catalogues.values():
+            if c.name == name_or_uuid or c.uuid == name_or_uuid:
+                return c
+        raise KeyError(name_or_uuid)
+
+
+def test_cocat_create_catalog_preserves_subpath(qtbot, qapp):
+    """Creating a catalog under a nested folder must store the sub-path
+    (regression for the bug where nested catalogs collapsed to the room root)."""
+    mod = _load_cocat_provider_module()
+    provider = mod.CocatCatalogProvider.__new__(mod.CocatCatalogProvider)
+    from SciQLop.components.catalogs.backend.provider import CatalogProvider
+    CatalogProvider.__init__(provider, name="Shared")
+    provider._url = ""
+    provider._catalog_map = {}
+    provider._available_rooms = ["room1"]
+    provider._default_room_id = "room1"
+    provider._connected = True
+    provider._client_for_listing = None
+    room = _FakeRoom()
+    provider._rooms = {"room1": room}
+
+    cat = provider.create_catalog("my_cat", path=["room1", "sub", "deeper"])
+
+    assert cat.path == ["room1", "sub", "deeper"]
+    cocat_cat = room.db._catalogues["my_cat"]
+    assert cocat_cat.attributes["sciqlop_path"] == "sub/deeper"
+
+
+def test_cocat_load_room_catalogs_restores_subpath(qtbot, qapp):
+    """Catalogs loaded from a room must recover their sub-path from attributes."""
+    mod = _load_cocat_provider_module()
+    provider = mod.CocatCatalogProvider.__new__(mod.CocatCatalogProvider)
+    from SciQLop.components.catalogs.backend.provider import CatalogProvider
+    CatalogProvider.__init__(provider, name="Shared")
+    provider._url = ""
+    provider._catalog_map = {}
+    provider._available_rooms = ["room1"]
+    provider._default_room_id = "room1"
+    provider._connected = True
+    provider._client_for_listing = None
+    room = _FakeRoom()
+    room.db._catalogues["root_cat"] = _FakeCatalogue("root_cat")
+    room.db._catalogues["nested_cat"] = _FakeCatalogue(
+        "nested_cat", attributes={"sciqlop_path": "a/b"}
+    )
+    provider._rooms = {"room1": room}
+
+    provider._load_room_catalogs("room1", room)
+
+    paths = {c.name: c.path for c in provider._catalog_map.values()}
+    assert paths["root_cat"] == ["room1"]
+    assert paths["nested_cat"] == ["room1", "a", "b"]
 
 
 # --- Inline catalog editing ---

--- a/tests/test_catalog_user_api.py
+++ b/tests/test_catalog_user_api.py
@@ -4,12 +4,16 @@ from datetime import datetime, timedelta, timezone
 from SciQLop.components.catalogs.backend.provider import CatalogProvider, Catalog, CatalogEvent
 
 
-def test_parse_path_single_slash():
+def test_parse_path_single_slash_rejected():
     from SciQLop.user_api.catalogs._service import _parse_path
-    provider, path, name = _parse_path("tscat/My Catalog")
-    assert provider == "tscat"
-    assert path == []
-    assert name == "My Catalog"
+    with pytest.raises(ValueError, match="must be separated by '//'"):
+        _parse_path("tscat/My Catalog")
+
+
+def test_parse_path_mixed_separators_rejected():
+    from SciQLop.user_api.catalogs._service import _parse_path
+    with pytest.raises(ValueError, match="must be separated by '//'"):
+        _parse_path("Shared//Bepi MSA/test")
 
 
 def test_parse_path_double_slash():
@@ -28,12 +32,10 @@ def test_parse_path_double_slash_nested():
     assert name == "My Catalog"
 
 
-def test_parse_path_name_with_slash():
+def test_parse_path_name_with_slash_rejected():
     from SciQLop.user_api.catalogs._service import _parse_path
-    provider, path, name = _parse_path("cocat//room1//Cat/with slash")
-    assert provider == "cocat"
-    assert path == ["room1"]
-    assert name == "Cat/with slash"
+    with pytest.raises(ValueError, match="cannot contain '/'"):
+        _parse_path("cocat//room1//Cat/with slash")
 
 
 def test_parse_path_too_short():

--- a/tests/test_panel_catalog_manager.py
+++ b/tests/test_panel_catalog_manager.py
@@ -41,6 +41,55 @@ def test_manager_remove_catalog(qtbot, qapp):
     assert cat.uuid not in manager.catalog_uuids
 
 
+def test_manager_drops_overlay_when_provider_removes_catalog(qtbot, qapp):
+    """When a provider emits catalog_removed (e.g. catalog deleted from the
+    tree or from a collaborative backend), any panel displaying that catalog
+    must drop its overlay. Regression: overlay would stay live, referencing
+    a deleted catalog."""
+    from SciQLop.components.catalogs.backend.panel_manager import PanelCatalogManager
+    from SciQLop.components.catalogs.backend.dummy_provider import DummyProvider
+    from SciQLop.components.plotting.ui.time_sync_panel import TimeSyncPanel
+    from SciQLop.core import TimeRange
+
+    panel = TimeSyncPanel("test-panel")
+    base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    panel.time_range = TimeRange(base.timestamp(), (base + timedelta(days=200)).timestamp())
+
+    provider = DummyProvider(num_catalogs=1, events_per_catalog=3)
+    cat = provider.catalogs()[0]
+
+    manager = PanelCatalogManager(panel)
+    manager.add_catalog(cat)
+    assert cat.uuid in manager.catalog_uuids
+
+    provider.remove_catalog(cat)
+
+    assert cat.uuid not in manager.catalog_uuids
+
+
+def test_manager_syncs_with_provider_registered_after_construction(qtbot, qapp):
+    """A provider registered after the PanelCatalogManager is created must
+    still have its catalog_removed signal honored by the panel."""
+    from SciQLop.components.catalogs.backend.panel_manager import PanelCatalogManager
+    from SciQLop.components.catalogs.backend.dummy_provider import DummyProvider
+    from SciQLop.components.plotting.ui.time_sync_panel import TimeSyncPanel
+    from SciQLop.core import TimeRange
+
+    panel = TimeSyncPanel("test-panel")
+    base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    panel.time_range = TimeRange(base.timestamp(), (base + timedelta(days=200)).timestamp())
+
+    manager = PanelCatalogManager(panel)
+
+    provider = DummyProvider(num_catalogs=1, events_per_catalog=1)
+    cat = provider.catalogs()[0]
+    manager.add_catalog(cat)
+    assert cat.uuid in manager.catalog_uuids
+
+    provider.remove_catalog(cat)
+    assert cat.uuid not in manager.catalog_uuids
+
+
 def test_manager_interaction_mode(qtbot, qapp):
     from SciQLop.components.catalogs.backend.panel_manager import (
         PanelCatalogManager, InteractionMode,

--- a/uv.lock
+++ b/uv.lock
@@ -1385,7 +1385,7 @@ wheels = [
 
 [[package]]
 name = "jupyqt"
-version = "0.5.0"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1396,9 +1396,9 @@ dependencies = [
     { name = "jupyverse", extra = ["jupyterlab"] },
     { name = "pyside6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/cf/c4aad354bff4bdd3a2e000b7e7222bce54c196fe3a5bc724259d281719ac/jupyqt-0.5.0.tar.gz", hash = "sha256:dd5a43e7d80b22d45002f52455fc46bbff278cb8f37e87c657785abc00414d9a", size = 66230, upload-time = "2026-04-08T09:52:33.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/40/1aebb75f2b83ec333649b93b2a98abbfe0fe6e719ef582064cb827bddfca/jupyqt-0.5.2.tar.gz", hash = "sha256:9a8bee5b2fc62b6b4ccd5063ce54a1e10cbfa72074f402af121d8dc3ace0b0fa", size = 70637, upload-time = "2026-04-13T19:20:35.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/0b/76ecd58b176130994ca991980e4ef9763286cf7cc59724086153cf400a1a/jupyqt-0.5.0-py3-none-any.whl", hash = "sha256:270cdc1d09c40ca6f3e9922b9412aa88e0e0250b6dcc59c1cd4ab04ae5fbcb99", size = 25749, upload-time = "2026-04-08T09:52:31.587Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c3/68e1d6b3348b1d5830f736daae8b20f965e4459beed5aa27b0c3b211b63b/jupyqt-0.5.2-py3-none-any.whl", hash = "sha256:c0d59c38908607eadd62e43dcde0f032fd95261d94df5f76a7b16c7b4d2ddbfd", size = 28160, upload-time = "2026-04-13T19:20:33.963Z" },
 ]
 
 [[package]]
@@ -2194,7 +2194,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2855,8 +2855,8 @@ name = "pytest-xvfb"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
-    { name = "pyvirtualdisplay" },
+    { name = "pytest", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyvirtualdisplay", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/ce/b3444c98eab123b7348d55d4705c2f1095a6bdf8dae85bc6a34ab5222845/pytest_xvfb-3.1.1.tar.gz", hash = "sha256:90593634427d974b272e845793e4533f5b827c9d84c051879013624504175e44", size = 9022, upload-time = "2025-03-12T12:35:07.533Z" }
 wheels = [
@@ -3382,7 +3382,7 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'" },
     { name = "ipython" },
     { name = "jinja2" },
-    { name = "jupyqt", specifier = ">=0.5.0" },
+    { name = "jupyqt", specifier = ">=0.5.2" },
     { name = "keyring" },
     { name = "matplotlib", specifier = "==3.10.8" },
     { name = "numpy" },
@@ -3462,8 +3462,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- **Panel overlay sync on delete** — `PanelCatalogManager` now listens to `CatalogProvider.catalog_removed` (for both existing and late-registered providers) and drops the corresponding overlay. Previously deleting a catalog left every panel holding a live `CatalogOverlay` pointing at the now-deleted `Catalog`, still rendering its events and breaking UUID-keyed menu toggling.
- **Cocat nested sub-paths** — catalog sub-paths beneath a room are now encoded into the cocat catalogue's `sciqlop_path` attribute and decoded on load, so nested catalogs survive round-trips instead of collapsing to the room root. Room membership checks now tolerate nested segments.
- **Late-capability placeholders** — when `folder_added` is re-emitted after a provider's capabilities change (cocat re-emits on room join once `CREATE_CATALOGS` is granted), the tree model now walks into the inserted folder and installs the `New Catalog.../New Folder...` placeholders.
- **Strict user-API path parsing** — `_parse_path` rejects mixed separators and single-slash paths with a clear `ValueError`, instead of silently mangling paths like `Shared//Bepi MSA/test`. Public contract is now `//`-only.
- **chore**: bump `jupyqt` to `0.5.2`.

## Test plan

- [x] New reproducer `test_manager_drops_overlay_when_provider_removes_catalog` fails on main and passes with the fix
- [x] New reproducer `test_manager_syncs_with_provider_registered_after_construction` covers providers added post-construction
- [x] New `test_tree_model_placeholders_added_on_late_folder_event` regression for the cocat late-caps case
- [x] New `test_cocat_create_catalog_preserves_subpath` / `test_cocat_load_room_catalogs_restores_subpath` cover nested sub-path round-trip
- [x] Updated `test_catalog_user_api.py` asserts single-slash and mixed-separator paths raise
- [x] `tests/test_panel_catalog_manager.py` full suite passes (16/16)
- [x] Manual: delete a catalog from the tree while a panel displays it — overlay disappears
- [x] Manual: create a nested catalog in a cocat room, reconnect, verify the sub-path is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)