### PR TITLE
fix(cocat): propagate CRDT updates to UI without leave/join cycle

### DIFF
--- a/SciQLop/components/settings/backend/entry.py
+++ b/SciQLop/components/settings/backend/entry.py
@@ -45,17 +45,32 @@ def _load_keyring(mapping: KeyringMapping, data: dict) -> None:
     service = data.get(mapping.service_field, "").rstrip("/")
     if not service:
         return
-    try:
-        creds = keyring.get_credential(service, None)
-    except Exception as e:
-        log.debug("Cannot read credentials from keyring for %s: %s", service, e)
-        return
-    if creds is None:
-        return
-    if not data.get(mapping.username_field):
+    username = data.get(mapping.username_field, "")
+    if not username:
+        # Migration path: older SciQLop versions (≤0.11.3) never persisted the
+        # username to YAML and relied on keyring.get_credential(service, None).
+        # That query is only supported by backends that override get_credential
+        # (Linux SecretService, Windows). On first run after the fix, recover
+        # the pair and let save() write the username back to YAML.
+        try:
+            creds = keyring.get_credential(service, None)
+        except Exception as e:
+            log.debug("Cannot read credentials from keyring for %s: %s", service, e)
+            return
+        if creds is None:
+            return
         data[mapping.username_field] = creds.username
-    if not data.get(mapping.password_field):
         data[mapping.password_field] = creds.password
+        return
+    if data.get(mapping.password_field):
+        return
+    try:
+        password = keyring.get_password(service, username)
+    except Exception as e:
+        log.debug("Cannot read password from keyring for %s: %s", service, e)
+        return
+    if password:
+        data[mapping.password_field] = password
 
 
 def _save_keyring(mapping: KeyringMapping, data: dict) -> None:
@@ -63,7 +78,7 @@ def _save_keyring(mapping: KeyringMapping, data: dict) -> None:
     service = data.get(mapping.service_field, "").rstrip("/")
     username = data.get(mapping.username_field, "")
     password = data.get(mapping.password_field, "")
-    if not service or not username:
+    if not service or not username or not password:
         return
     try:
         keyring.set_password(service, username, password)
@@ -114,7 +129,7 @@ class ConfigEntry(BaseModel):
         m = cls._keyring_
         if m is None:
             return set()
-        return {m.username_field, m.password_field}
+        return {m.password_field}
 
     def __init__(self, **data):
         save = True

--- a/SciQLop/plugins/collaborative_catalogs/cocat_provider.py
+++ b/SciQLop/plugins/collaborative_catalogs/cocat_provider.py
@@ -82,6 +82,14 @@ class CocatEvent(CatalogEvent):
     def _apply(self) -> None:
         self._cocat_event.range = (self._start, self._stop)
 
+    def update_from_cocat(self, start: datetime, stop: datetime) -> None:
+        """Apply a remote (CRDT) range update without re-triggering _apply()."""
+        if start == self._start and stop == self._stop:
+            return
+        self._start = start
+        self._stop = stop
+        self.range_changed.emit()
+
 
 class CocatCatalogProvider(CatalogProvider):
     """Multi-room CoCat provider. Always registered; rooms are joined on demand."""
@@ -184,19 +192,79 @@ class CocatCatalogProvider(CatalogProvider):
             asyncio.ensure_future(room.close())
 
     def _load_room_catalogs(self, room_id: str, room) -> None:
+        room.db.on_create_catalogue(
+            lambda cocat_cat: self._wrap_remote_catalogue(room_id, cocat_cat)
+        )
         for cat_name in room.catalogues:
             cocat_cat = room.get_catalogue(cat_name)
-            sub_path = _decode_subpath(cocat_cat.attributes.get(_SUBPATH_ATTR))
-            cat = Catalog(
-                uuid=str(cocat_cat.uuid) if hasattr(cocat_cat, 'uuid') else cat_name,
-                name=cat_name,
-                provider=self,
-                path=[room_id, *sub_path],
-            )
-            self._catalog_map[cat.uuid] = cat
-            events = [CocatEvent(ev, parent=self) for ev in cocat_cat.events]
-            self._set_events(cat, events)
-            self.catalog_added.emit(cat)
+            self._wrap_catalogue(room_id, cocat_cat)
+
+    def _wrap_catalogue(self, room_id: str, cocat_cat) -> Catalog:
+        sub_path = _decode_subpath(cocat_cat.attributes.get(_SUBPATH_ATTR))
+        cat = Catalog(
+            uuid=str(cocat_cat.uuid) if hasattr(cocat_cat, 'uuid') else cocat_cat.name,
+            name=cocat_cat.name,
+            provider=self,
+            path=[room_id, *sub_path],
+        )
+        self._catalog_map[cat.uuid] = cat
+        wrappers = [self._wrap_event(ev) for ev in cocat_cat.events]
+        self._set_events(cat, wrappers)
+        self._subscribe_catalogue(cocat_cat, cat)
+        self.catalog_added.emit(cat)
+        return cat
+
+    def _wrap_remote_catalogue(self, room_id: str, cocat_cat) -> None:
+        uuid = str(cocat_cat.uuid) if hasattr(cocat_cat, 'uuid') else cocat_cat.name
+        if uuid in self._catalog_map:
+            return
+        self._wrap_catalogue(room_id, cocat_cat)
+
+    def _wrap_event(self, cocat_event) -> CocatEvent:
+        wrapper = CocatEvent(cocat_event, parent=self)
+        cocat_event.on_change_range(
+            lambda start, stop, w=wrapper: w.update_from_cocat(start, stop)
+        )
+        return wrapper
+
+    def _subscribe_catalogue(self, cocat_cat, cat: Catalog) -> None:
+        cocat_cat.on_delete(lambda c=cat: self._on_remote_catalogue_deleted(c))
+        cocat_cat.on_change_name(
+            lambda name, c=cat: self._on_remote_catalogue_renamed(c, name)
+        )
+        cocat_cat.on_add_events(
+            lambda evs, c=cat: self._on_remote_events_added(c, evs)
+        )
+        cocat_cat.on_remove_events(
+            lambda uuids, c=cat: self._on_remote_events_removed(c, uuids)
+        )
+
+    def _on_remote_catalogue_deleted(self, cat: Catalog) -> None:
+        if cat.uuid not in self._catalog_map:
+            return
+        self._catalog_map.pop(cat.uuid, None)
+        CatalogProvider.remove_catalog(self, cat)
+
+    def _on_remote_catalogue_renamed(self, cat: Catalog, new_name: str) -> None:
+        if cat.name == new_name:
+            return
+        cat.name = new_name
+        self.catalog_renamed.emit(cat)
+
+    def _on_remote_events_added(self, cat: Catalog, cocat_events) -> None:
+        existing = {e.uuid for e in self._events.get(cat.uuid, [])}
+        for cocat_ev in cocat_events:
+            uuid = str(cocat_ev.uuid)
+            if uuid in existing:
+                continue
+            wrapper = self._wrap_event(cocat_ev)
+            self._add_event(cat, wrapper)
+
+    def _on_remote_events_removed(self, cat: Catalog, uuids) -> None:
+        targets = {str(u) for u in uuids}
+        for wrapper in list(self._events.get(cat.uuid, [])):
+            if wrapper.uuid in targets:
+                self._remove_event(cat, wrapper)
 
     def _room_for_catalog(self, catalog: Catalog):
         """Get the Room instance for a catalog's room."""
@@ -225,9 +293,9 @@ class CocatCatalogProvider(CatalogProvider):
             start=event.start, stop=event.stop, author="SciQLop",
             uuid=event.uuid,
         )
-        cocat_cat.add_events([cocat_event])
-        wrapped = CocatEvent(cocat_event, parent=self)
+        wrapped = self._wrap_event(cocat_event)
         self._add_event(catalog, wrapped)
+        cocat_cat.add_events([cocat_event])
 
     def remove_event(self, catalog: Catalog, event: CatalogEvent) -> None:
         cocat_cat = self._cocat_catalogue(catalog)
@@ -268,6 +336,7 @@ class CocatCatalogProvider(CatalogProvider):
         )
         self._catalog_map[cat.uuid] = cat
         self._set_events(cat, [])
+        self._subscribe_catalogue(cocat_cat, cat)
         self.catalog_added.emit(cat)
         return cat
 
@@ -276,21 +345,21 @@ class CocatCatalogProvider(CatalogProvider):
         if room is None:
             return
         cocat_cat = room.get_catalogue(catalog.uuid)
-        cocat_cat.name = new_name
         catalog.name = new_name
         self.catalog_renamed.emit(catalog)
+        cocat_cat.name = new_name
 
     def remove_catalog(self, catalog: Catalog) -> None:
         room = self._room_for_catalog(catalog)
         if room is None:
             return
         cocat_cat = room.get_catalogue(catalog.uuid)
+        self._catalog_map.pop(catalog.uuid, None)
+        super().remove_catalog(catalog)
         try:
             cocat_cat.delete()
         except ExceptionGroup:
             pass  # cocat observer bug: KeyError on _catalogue_change_callbacks cleanup
-        self._catalog_map.pop(catalog.uuid, None)
-        super().remove_catalog(catalog)
 
     def capabilities(self, catalog: Catalog | None = None) -> set[str]:
         if not self._rooms:

--- a/tests/test_catalog_provider.py
+++ b/tests/test_catalog_provider.py
@@ -850,22 +850,107 @@ def _load_cocat_provider_module():
     return mod
 
 
+class _FakeCocatEvent:
+    def __init__(self, uuid, start, stop):
+        self.uuid = uuid
+        self.start = start
+        self.stop = stop
+        self._range_cbs = []
+        self._delete_cbs = []
+
+    def on_change_range(self, cb):
+        self._range_cbs.append(cb)
+
+    def on_delete(self, cb):
+        self._delete_cbs.append(cb)
+
+    @property
+    def range(self):
+        return (self.start, self.stop)
+
+    @range.setter
+    def range(self, value):
+        self.start, self.stop = value
+        for cb in list(self._range_cbs):
+            cb(self.start, self.stop)
+
+    def delete(self):
+        for cb in list(self._delete_cbs):
+            cb()
+
+
 class _FakeCatalogue:
-    def __init__(self, name, attributes=None):
-        self.uuid = f"uuid-{name}"
+    def __init__(self, name, attributes=None, uuid=None):
+        self.uuid = uuid or f"uuid-{name}"
         self.name = name
         self.attributes = dict(attributes or {})
         self.events = []
+        self._add_events_cbs = []
+        self._remove_events_cbs = []
+        self._delete_cbs = []
+        self._rename_cbs = []
+
+    def on_add_events(self, cb):
+        self._add_events_cbs.append(cb)
+
+    def on_remove_events(self, cb):
+        self._remove_events_cbs.append(cb)
+
+    def on_delete(self, cb):
+        self._delete_cbs.append(cb)
+
+    def on_change_name(self, cb):
+        self._rename_cbs.append(cb)
+
+    def add_events(self, evs):
+        self.events.extend(evs)
+        for cb in list(self._add_events_cbs):
+            cb(evs)
+
+    def remove_events(self, evs):
+        uuids = [e.uuid for e in evs]
+        self.events = [e for e in self.events if e.uuid not in uuids]
+        for cb in list(self._remove_events_cbs):
+            cb(uuids)
+
+    def remote_rename(self, new_name):
+        self.name = new_name
+        for cb in list(self._rename_cbs):
+            cb(new_name)
+
+    def delete(self):
+        for cb in list(self._delete_cbs):
+            cb()
 
 
 class _FakeRoomDB:
     def __init__(self):
         self._catalogues: dict[str, _FakeCatalogue] = {}
+        self._events_by_uuid: dict[str, _FakeCocatEvent] = {}
+        self._create_cat_cbs = []
+
+    def on_create_catalogue(self, cb):
+        self._create_cat_cbs.append(cb)
 
     def create_catalogue(self, name, author, attributes=None):
         cat = _FakeCatalogue(name, attributes)
         self._catalogues[name] = cat
         return cat
+
+    def remote_create_catalogue(self, name, attributes=None):
+        cat = _FakeCatalogue(name, attributes)
+        self._catalogues[name] = cat
+        for cb in list(self._create_cat_cbs):
+            cb(cat)
+        return cat
+
+    def create_event(self, start, stop, author, uuid=None):
+        ev = _FakeCocatEvent(uuid or f"ev-{len(self._events_by_uuid)}", start, stop)
+        self._events_by_uuid[ev.uuid] = ev
+        return ev
+
+    def get_event(self, uuid):
+        return self._events_by_uuid[uuid]
 
 
 class _FakeRoom:
@@ -881,6 +966,22 @@ class _FakeRoom:
             if c.name == name_or_uuid or c.uuid == name_or_uuid:
                 return c
         raise KeyError(name_or_uuid)
+
+
+def _make_cocat_provider():
+    mod = _load_cocat_provider_module()
+    provider = mod.CocatCatalogProvider.__new__(mod.CocatCatalogProvider)
+    from SciQLop.components.catalogs.backend.provider import CatalogProvider
+    CatalogProvider.__init__(provider, name="Shared")
+    provider._url = ""
+    provider._catalog_map = {}
+    provider._available_rooms = ["room1"]
+    provider._default_room_id = "room1"
+    provider._connected = True
+    provider._client_for_listing = None
+    room = _FakeRoom()
+    provider._rooms = {"room1": room}
+    return mod, provider, room
 
 
 def test_cocat_create_catalog_preserves_subpath(qtbot, qapp):
@@ -930,6 +1031,148 @@ def test_cocat_load_room_catalogs_restores_subpath(qtbot, qapp):
     paths = {c.name: c.path for c in provider._catalog_map.values()}
     assert paths["root_cat"] == ["room1"]
     assert paths["nested_cat"] == ["room1", "a", "b"]
+
+
+# --- CRDT update propagation (remote peer events) ---
+
+def test_cocat_remote_catalogue_creation_propagates(qtbot, qapp):
+    """A catalogue created by a peer (CRDT sync) must appear in the provider
+    without requiring a leave/join cycle."""
+    mod, provider, room = _make_cocat_provider()
+    provider._load_room_catalogs("room1", room)
+
+    added = []
+    provider.catalog_added.connect(lambda c: added.append(c))
+
+    room.db.remote_create_catalogue("from_peer", attributes={"sciqlop_path": "x/y"})
+
+    assert any(c.name == "from_peer" for c in provider._catalog_map.values())
+    cat = next(c for c in provider._catalog_map.values() if c.name == "from_peer")
+    assert cat.path == ["room1", "x", "y"]
+    assert cat in added
+
+
+def test_cocat_remote_catalogue_deletion_propagates(qtbot, qapp):
+    """When a peer deletes a catalogue, the provider must drop it and emit
+    catalog_removed so panels can clear their overlays."""
+    mod, provider, room = _make_cocat_provider()
+    room.db._catalogues["shared"] = _FakeCatalogue("shared")
+    provider._load_room_catalogs("room1", room)
+
+    removed = []
+    provider.catalog_removed.connect(lambda c: removed.append(c))
+
+    cat = next(iter(provider._catalog_map.values()))
+    room.db._catalogues["shared"].delete()
+
+    assert cat.uuid not in provider._catalog_map
+    assert removed == [cat]
+
+
+def test_cocat_remote_catalogue_rename_propagates(qtbot, qapp):
+    mod, provider, room = _make_cocat_provider()
+    room.db._catalogues["old"] = _FakeCatalogue("old")
+    provider._load_room_catalogs("room1", room)
+
+    renamed = []
+    provider.catalog_renamed.connect(lambda c: renamed.append(c))
+
+    room.db._catalogues["old"].remote_rename("new_name")
+
+    cat = next(iter(provider._catalog_map.values()))
+    assert cat.name == "new_name"
+    assert renamed == [cat]
+
+
+def test_cocat_remote_events_added_propagates(qtbot, qapp):
+    mod, provider, room = _make_cocat_provider()
+    room.db._catalogues["c"] = _FakeCatalogue("c")
+    provider._load_room_catalogs("room1", room)
+
+    changed = []
+    provider.events_changed.connect(lambda c: changed.append(c))
+
+    t = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    ev = _FakeCocatEvent("ev1", t, t + timedelta(hours=1))
+    room.db._catalogues["c"].add_events([ev])
+
+    cat = next(iter(provider._catalog_map.values()))
+    evs = provider.events(cat)
+    assert len(evs) == 1
+    assert evs[0].uuid == "ev1"
+    assert changed and changed[-1] is cat
+
+
+def test_cocat_remote_events_removed_propagates(qtbot, qapp):
+    mod, provider, room = _make_cocat_provider()
+    t = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    cocat_cat = _FakeCatalogue("c")
+    ev = _FakeCocatEvent("ev1", t, t + timedelta(hours=1))
+    cocat_cat.events = [ev]
+    room.db._catalogues["c"] = cocat_cat
+    provider._load_room_catalogs("room1", room)
+
+    cat = next(iter(provider._catalog_map.values()))
+    assert len(provider.events(cat)) == 1
+
+    cocat_cat.remove_events([ev])
+
+    assert len(provider.events(cat)) == 0
+
+
+def test_cocat_remote_event_range_change_propagates(qtbot, qapp):
+    mod, provider, room = _make_cocat_provider()
+    t = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    cocat_cat = _FakeCatalogue("c")
+    ev = _FakeCocatEvent("ev1", t, t + timedelta(hours=1))
+    cocat_cat.events = [ev]
+    room.db._catalogues["c"] = cocat_cat
+    provider._load_room_catalogs("room1", room)
+
+    cat = next(iter(provider._catalog_map.values()))
+    wrapper = provider.events(cat)[0]
+
+    range_changed_hits = []
+    wrapper.range_changed.connect(lambda: range_changed_hits.append(1))
+
+    new_start = datetime(2022, 6, 15, tzinfo=timezone.utc)
+    new_stop = datetime(2022, 6, 16, tzinfo=timezone.utc)
+    ev.range = (new_start, new_stop)
+
+    assert wrapper.start == new_start
+    assert wrapper.stop == new_stop
+    assert range_changed_hits
+
+
+def test_cocat_local_remove_catalog_does_not_double_emit(qtbot, qapp):
+    """Local remove_catalog triggers cocat.on_delete synchronously. The handler
+    must be idempotent — exactly one catalog_removed emission."""
+    mod, provider, room = _make_cocat_provider()
+    room.db._catalogues["c"] = _FakeCatalogue("c")
+    provider._load_room_catalogs("room1", room)
+
+    removed = []
+    provider.catalog_removed.connect(lambda c: removed.append(c))
+
+    cat = next(iter(provider._catalog_map.values()))
+    provider.remove_catalog(cat)
+
+    assert len(removed) == 1
+
+
+def test_cocat_local_add_event_does_not_double_wrap(qtbot, qapp):
+    """Local add_event triggers cocat.on_add_events synchronously. The handler
+    must dedupe so we don't end up with two wrappers for the same event."""
+    mod, provider, room = _make_cocat_provider()
+    room.db._catalogues["c"] = _FakeCatalogue("c")
+    provider._load_room_catalogs("room1", room)
+
+    cat = next(iter(provider._catalog_map.values()))
+    from SciQLop.components.catalogs.backend.provider import CatalogEvent
+    t = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    provider.add_event(cat, CatalogEvent(uuid="ev-new", start=t, stop=t + timedelta(hours=1)))
+
+    assert len(provider.events(cat)) == 1
 
 
 # --- Inline catalog editing ---

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -124,3 +124,140 @@ def test_settings_model_node_from_invalid_index(qtbot, qapp, tmp_config_dir):
     model.rebuild()
     node = model.node_from_index(QModelIndex())
     assert node is model.root()
+
+
+# --- Keyring-backed credentials ---
+
+class _FakeKeyring:
+    """Stub backend that mimics macOS: no get_credential, only get/set_password."""
+
+    def __init__(self):
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service, username, password):
+        self.store[(service, username)] = password
+
+    def get_password(self, service, username):
+        return self.store.get((service, username))
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch):
+    import keyring as kr
+    fake = _FakeKeyring()
+    monkeypatch.setattr(kr, "set_password", fake.set_password)
+    monkeypatch.setattr(kr, "get_password", fake.get_password)
+
+    def _no_credential(*_a, **_kw):
+        return None
+    monkeypatch.setattr(kr, "get_credential", _no_credential)
+    return fake
+
+
+def _make_cred_entry(name, tmp_config_dir):
+    from SciQLop.components.settings.backend.entry import KeyringMapping
+    annotations = {"server_url": str, "username": str, "password": str}
+    ns = {
+        "__annotations__": annotations,
+        "category": "test", "subcategory": "sub",
+        "server_url": "https://example.test/svc",
+        "username": "",
+        "password": "",
+        "_keyring_": KeyringMapping("server_url", "username", "password"),
+    }
+    return type(name, (ConfigEntry,), ns)
+
+
+def test_keyring_credentials_persist_across_reload(tmp_config_dir, fake_keyring):
+    """Regression: on macOS the base-class get_credential returns None for
+    username=None, so credentials saved via set_password were never loaded
+    back. Loading must use get_password with the stored username."""
+    cls = _make_cred_entry("CredEntry1", tmp_config_dir)
+
+    instance = cls()
+    instance.username = "alice@example.test"
+    instance.password = "s3cret"
+    instance.save()
+
+    assert ("https://example.test/svc", "alice@example.test") in fake_keyring.store
+    assert fake_keyring.store[("https://example.test/svc", "alice@example.test")] == "s3cret"
+
+    reloaded = cls()
+    assert reloaded.username == "alice@example.test"
+    assert reloaded.password == "s3cret"
+
+
+def test_keyring_username_persisted_to_yaml(tmp_config_dir, fake_keyring):
+    """Username is a non-secret identifier — it must be stored in YAML so we
+    can look up the password in the keyring on reload."""
+    import yaml
+    cls = _make_cred_entry("CredEntry2", tmp_config_dir)
+    instance = cls()
+    instance.username = "bob@example.test"
+    instance.password = "hunter2"
+    instance.save()
+
+    with open(cls.config_file()) as f:
+        dumped = yaml.safe_load(f)
+    assert dumped["username"] == "bob@example.test"
+    assert "password" not in dumped or not dumped["password"]
+
+
+def test_keyring_legacy_linux_yaml_migration(tmp_config_dir, monkeypatch):
+    """Linux users upgrading from ≤0.11.3 have YAML without a username field
+    (older code popped it before dumping). On Linux/Windows the keyring
+    backend supports get_credential(service, None), so we must fall back to
+    it, recover the pair, and persist the username back to YAML on save()."""
+    import yaml
+    import keyring as kr
+
+    store: dict[tuple[str, str], str] = {
+        ("https://example.test/svc", "dave@example.test"): "legacy-pw",
+    }
+
+    class _Cred:
+        def __init__(self, username, password):
+            self.username = username
+            self.password = password
+
+    def _get_credential(service, username):
+        if username is None:
+            for (svc, user), pw in store.items():
+                if svc == service:
+                    return _Cred(user, pw)
+            return None
+        pw = store.get((service, username))
+        return _Cred(username, pw) if pw else None
+
+    monkeypatch.setattr(kr, "get_credential", _get_credential)
+    monkeypatch.setattr(kr, "get_password",
+                        lambda service, username: store.get((service, username)))
+    monkeypatch.setattr(kr, "set_password",
+                        lambda service, username, password: store.update({(service, username): password}))
+
+    cls = _make_cred_entry("CredEntryMigrate", tmp_config_dir)
+    # Write legacy YAML: no username field, empty password
+    with open(cls.config_file(), "w") as f:
+        yaml.safe_dump({"server_url": "https://example.test/svc"}, f)
+
+    instance = cls()
+    assert instance.username == "dave@example.test"
+    assert instance.password == "legacy-pw"
+
+    instance.save()
+    with open(cls.config_file()) as f:
+        dumped = yaml.safe_load(f)
+    assert dumped["username"] == "dave@example.test"
+
+
+def test_keyring_empty_password_not_saved(tmp_config_dir, fake_keyring):
+    """Partial edits (username without a password yet) must not overwrite an
+    existing keyring entry with an empty password."""
+    cls = _make_cred_entry("CredEntry3", tmp_config_dir)
+    fake_keyring.store[("https://example.test/svc", "carol@example.test")] = "existing"
+
+    instance = cls()
+    instance.username = "carol@example.test"
+    instance.save()
+
+    assert fake_keyring.store[("https://example.test/svc", "carol@example.test")] == "existing"

--- a/uv.lock
+++ b/uv.lock
@@ -3335,7 +3335,7 @@ wheels = [
 
 [[package]]
 name = "sciqlop"
-version = "0.11.2"
+version = "0.11.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "expression" },


### PR DESCRIPTION
## Summary

`CocatCatalogProvider` never subscribed to any cocat observer callback, so any catalog or event created/modified by a peer via CRDT stayed invisible locally until a leave/join rebuilt state from the current snapshot. This PR wires the missing observers.

- `db.on_create_catalogue` → remote catalog creation (origin-filtered by cocat, so it only fires for peer writes)
- Per catalogue: `on_delete`, `on_change_name`, `on_add_events`, `on_remove_events`
- Per event: `on_change_range`

Catalogue- and event-level callbacks fire for **both** local and remote writes (cocat's origin filter only applies at the DB level), so every handler is idempotent via uuid-based dedupe. Local action methods (`add_event`, `rename_catalog`, `remove_catalog`) now update wrapper state **before** calling into cocat so the synchronous echo callback trivially no-ops.

New `CocatEvent.update_from_cocat()` bypasses the property setter when applying remote range changes, avoiding the 100 ms deferred `_apply()` feedback loop that would otherwise write back to cocat and re-fire the callback.

## Test plan

- [x] 6 reproducer tests for remote propagation (create/delete/rename catalog, add/remove/range-change event) — all failing on `main`, passing after fix
- [x] 2 idempotency tests for local actions (no double `catalog_removed` emission, no double-wrapped event) — pass
- [x] Full catalog suite green (1 pre-existing unrelated failure in `test_event_table_model_meta_columns` present on `main`)
- [ ] Manual verification with two SciQLop instances connected to the same cocat room

🤖 Generated with [Claude Code](https://claude.com/claude-code)