### PR TITLE
feat(plotting): provider-driven PlotHints with multi-product aggregation

### DIFF
--- a/SciQLop/components/plotting/backend/data_provider.py
+++ b/SciQLop/components/plotting/backend/data_provider.py
@@ -4,6 +4,7 @@ import traceback
 import numpy as np
 
 from SciQLop.core.enums import DataOrder, GraphType
+from SciQLop.core.plot_hints import PlotHints
 from SciQLop.components import sciqlop_logging
 from speasy.products import SpeasyVariable, VariableAxis
 from speasy.core import datetime64_to_epoch
@@ -66,10 +67,26 @@ class DataProvider:
     def graph_type(self, node) -> GraphType:
         pass
 
-    def _get_data(self, node, start, stop) -> Union[
+    def plot_hints(self, node) -> PlotHints:
+        return PlotHints()
+
+    def plot_hints_from_variable(self, node, variable) -> PlotHints:
+        """Compute extra hints from a successfully fetched data variable.
+
+        Called at most once per plot, after the first fetch that returned
+        non-empty data. Defaults to no extra hints.
+        """
+        return PlotHints()
+
+    def _get_data(self, node, start, stop, on_variable=None) -> Union[
         List[np.ndarray], Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, np.ndarray]]:
         try:
             v = self.get_data(node, start, stop)
+            if v is not None and on_variable is not None:
+                try:
+                    on_variable(v)
+                except Exception:
+                    log.debug("on_variable callback failed", exc_info=True)
             if v is None:
                 return []
             if isinstance(v, list) or isinstance(v, tuple):

--- a/SciQLop/components/plotting/ui/time_sync_panel.py
+++ b/SciQLop/components/plotting/ui/time_sync_panel.py
@@ -13,6 +13,9 @@ from SciQLop.core import TimeRange
 from SciQLop.core import listify
 from SciQLop.components import sciqlop_logging
 from SciQLop.components.plotting.backend.data_provider import providers, DataProvider
+import weakref
+
+from SciQLop.core.plot_hints import apply_plot_hints, combine_hints, merge_hints, PlotHints
 from SciQLop.core.property import SciQLopProperty
 from SciQLop.core.mime import decode_mime
 from SciQLop.core.mime.types import PRODUCT_LIST_MIME_TYPE, TIME_RANGE_MIME_TYPE
@@ -24,14 +27,136 @@ log = sciqlop_logging.getLogger(__name__)
 register_icon("QCP", QIcon("://icons/QCP.png"))
 
 
+def _variable_is_successful(v) -> bool:
+    if v is None:
+        return False
+    try:
+        return len(v) > 0
+    except TypeError:
+        return True
+
+
+import shiboken6
+
+_PLOT_REGISTRIES: dict[int, "_PlotHintsRegistry"] = {}
+
+
+def _plot_key(plot) -> Optional[int]:
+    try:
+        return int(shiboken6.getCppPointer(plot)[0])
+    except Exception:
+        return id(plot)
+
+
+def _graph_key(graph) -> int:
+    try:
+        return int(shiboken6.getCppPointer(graph)[0])
+    except Exception:
+        return id(graph)
+
+
+class _PlotHintsRegistry:
+    """Per-plot accumulator of per-graph PlotHints.
+
+    When several products are plotted on one plot (e.g. two line products),
+    the y-axis label becomes the comma-joined list of each product's composed
+    label. Graphs auto-deregister via their QObject.destroyed signal so
+    removing a product cleans up the label without a manual refresh.
+
+    Keyed by C++ pointers (not by Python wrapper identity, which shiboken
+    does not preserve across calls).
+    """
+
+    def __init__(self, plot):
+        self._plot = plot  # strong ref; evicted from _PLOT_REGISTRIES on destroyed
+        self._entries: dict[int, PlotHints] = {}
+
+    def register(self, graph, hints: PlotHints) -> int:
+        key = _graph_key(graph)
+        self._entries[key] = hints
+        try:
+            graph.destroyed.connect(lambda *_, k=key: self._drop(k))
+        except (AttributeError, RuntimeError):
+            log.debug("graph has no destroyed signal; leak-resistant cleanup off")
+        self._recompute()
+        return key
+
+    def update_if_present(self, key: int, hints: PlotHints) -> None:
+        if key in self._entries:
+            self._entries[key] = hints
+            self._recompute()
+
+    def _drop(self, key: int) -> None:
+        if self._entries.pop(key, None) is not None:
+            self._recompute()
+
+    def _recompute(self) -> None:
+        try:
+            apply_plot_hints(self._plot, combine_hints(list(self._entries.values())))
+        except RuntimeError:
+            log.debug("plot already destroyed during hints recompute")
+
+
+def _get_or_create_registry(plot) -> Optional["_PlotHintsRegistry"]:
+    if plot is None:
+        return None
+    key = _plot_key(plot)
+    if key is None:
+        return _PlotHintsRegistry(plot)
+    reg = _PLOT_REGISTRIES.get(key)
+    if reg is None:
+        reg = _PlotHintsRegistry(plot)
+        _PLOT_REGISTRIES[key] = reg
+        try:
+            plot.destroyed.connect(lambda *_, k=key: _PLOT_REGISTRIES.pop(k, None))
+        except (AttributeError, RuntimeError):
+            log.debug("plot has no destroyed signal; registry leaks until app exit")
+    return reg
+
+
+class _PostFetchHintsApplier:
+    """Refines a graph's hints via provider.plot_hints_from_variable() on the
+    first successful fetch, then updates the plot's registry entry — so the
+    combined label reflects the richer post-fetch information."""
+
+    def __init__(self, provider: DataProvider, node, registry: Optional["_PlotHintsRegistry"],
+                 graph_key: int, base_hints: PlotHints):
+        self._provider = provider
+        self._node = node
+        self._registry_ref = weakref.ref(registry) if registry is not None else None
+        self._graph_key = graph_key
+        self._base_hints = base_hints
+        self._applied = False
+
+    def observe(self, variable) -> None:
+        if self._applied:
+            return
+        if not _variable_is_successful(variable):
+            return
+        reg = self._registry_ref() if self._registry_ref is not None else None
+        if reg is None:
+            self._applied = True
+            return
+        try:
+            extra = self._provider.plot_hints_from_variable(self._node, variable)
+        except Exception:
+            log.debug("plot_hints_from_variable failed for %s", self._node, exc_info=True)
+            self._applied = True
+            return
+        reg.update_if_present(self._graph_key, merge_hints(self._base_hints, extra))
+        self._applied = True
+
+
 class _plot_product_callback:
-    def __init__(self, provider: DataProvider, node):
+    def __init__(self, provider: DataProvider, node, post_fetch: Optional["_PostFetchHintsApplier"] = None):
         self.provider = provider
         self.node = node
+        self._post_fetch = post_fetch
 
     def __call__(self, start, stop):
         try:
-            return self.provider._get_data(self.node, start, stop)
+            observer = self._post_fetch.observe if self._post_fetch is not None else None
+            return self.provider._get_data(self.node, start, stop, on_variable=observer)
         except Exception as e:
             log.error(f"Error getting data for {self.node}: {e}")
             return []
@@ -47,10 +172,11 @@ def _y_is_descending(y):
 
 
 class _specgram_callback:
-    def __init__(self, provider: DataProvider, node):
+    def __init__(self, provider: DataProvider, node, post_fetch: Optional["_PostFetchHintsApplier"] = None):
         self.provider = provider
         self.node = node
         self._y_is_descending_ = None
+        self._post_fetch = post_fetch
 
     def _y_is_descending(self, y):
         if self._y_is_descending_ is None:
@@ -60,7 +186,8 @@ class _specgram_callback:
 
     def __call__(self, start, stop):
         try:
-            x, y, z = self.provider._get_data(self.node, start, stop)
+            observer = self._post_fetch.observe if self._post_fetch is not None else None
+            x, y, z = self.provider._get_data(self.node, start, stop, on_variable=observer)
             if self._y_is_descending(y):
                 if len(y.shape) == 1:
                     y = y[::-1].copy()
@@ -97,6 +224,42 @@ def _theme_from_palette(palette: dict[str, str], parent=None) -> SciQLopTheme:
 def _set_product_path(r, product_path_str):
     graph = r[1] if hasattr(r, '__iter__') else r
     graph.setProperty("sqp_product_path", product_path_str)
+
+
+def _plot_from_result(r, target):
+    """Extract the plot object from target.plot()'s return value.
+
+    target.plot() may return a graph (when target is already a SciQLopPlot),
+    or a (plot, graph) tuple (when target is a SciQLopMultiPlotPanel that
+    created a new subplot). In the first case the plot is the target itself.
+    """
+    if hasattr(r, '__iter__'):
+        return r[0]
+    if isinstance(target, SciQLopPlot):
+        return target
+    return None
+
+
+def _safe_plot_hints(provider, node) -> PlotHints:
+    try:
+        return provider.plot_hints(node)
+    except Exception:
+        log.debug("plot_hints failed for %s", node, exc_info=True)
+        return PlotHints()
+
+
+def _graph_from_result(r):
+    return r[1] if hasattr(r, '__iter__') else r
+
+
+def _register_graph_hints(provider, node, r, target) -> Optional["_PostFetchHintsApplier"]:
+    plot = _plot_from_result(r, target)
+    registry = _get_or_create_registry(plot)
+    if registry is None:
+        return None
+    base_hints = _safe_plot_hints(provider, node)
+    graph_key = registry.register(_graph_from_result(r), base_hints)
+    return _PostFetchHintsApplier(provider, node, registry, graph_key, base_hints)
 
 
 def _resolve_plot_target(p, kwargs):
@@ -145,6 +308,7 @@ def plot_product(p: Union[SciQLopPlot, SciQLopMultiPlotPanel, SciQLopNDProjectio
                         if existing_plot is not None:
                             r = (existing_plot, r)
                     _set_product_path(r, product_path_str)
+                    callback._post_fetch = _register_graph_hints(provider, node, r, target)
                     return r
                 elif node.parameter_type() == ParameterType.Spectrogram:
                     callback = _specgram_callback(provider, node)
@@ -154,6 +318,7 @@ def plot_product(p: Union[SciQLopPlot, SciQLopMultiPlotPanel, SciQLopNDProjectio
                     if not hasattr(r, '__iter__') and existing_plot is not None:
                         r = (existing_plot, r)
                     _set_product_path(r, product_path_str)
+                    callback._post_fetch = _register_graph_hints(provider, node, r, target)
                     return r
     log.debug(f"Product not found: {product}")
     return None

--- a/SciQLop/core/istp_hints.py
+++ b/SciQLop/core/istp_hints.py
@@ -1,0 +1,158 @@
+"""ISTP metadata → PlotHints translation.
+
+Pure function shared by any provider whose upstream metadata follows the
+ISTP/CDF convention (speasy inventory indexes, cdf_workbench variable info,
+HAPI servers that re-publish CDAWeb data, ...).
+
+No Qt dependency — fully unit-testable.
+"""
+from __future__ import annotations
+
+import ast
+from typing import Any, Iterable, Mapping, Optional
+
+from SciQLop.core.plot_hints import AxisHints, PlotHints
+
+
+def _first(value: Any) -> Any:
+    """Return the first scalar of a list/tuple attribute, or the value itself."""
+    while isinstance(value, (list, tuple)) and len(value) > 0:
+        value = value[0]
+    return value
+
+
+def _as_str(value: Any) -> Optional[str]:
+    value = _first(value)
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    value = _first(value)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _scale(value: Any) -> Optional[str]:
+    s = _as_str(value)
+    if s is None:
+        return None
+    s = s.lower()
+    if s.startswith("log"):
+        return "log"
+    if s.startswith("lin"):
+        return "linear"
+    return None
+
+
+def _display_type(value: Any) -> Optional[str]:
+    s = _as_str(value)
+    if s is None:
+        return None
+    s = s.lower().strip()
+    if s.startswith("spectrogram"):
+        return "spectrogram"
+    if s in ("time_series", "timeseries", "time series", "line", "plot"):
+        return "line"
+    return None
+
+
+def _component_labels(meta: Mapping[str, Any]) -> Optional[list[str]]:
+    raw = meta.get("LABL_PTR_1")
+    if raw is not None:
+        if isinstance(raw, (list, tuple)) and len(raw) > 0:
+            if len(raw) == 1 and isinstance(raw[0], str):
+                return _parse_list_string(raw[0])
+            return [str(v) for v in raw]
+        if isinstance(raw, str):
+            return _parse_list_string(raw)
+    lablaxis = meta.get("LABLAXIS")
+    if isinstance(lablaxis, (list, tuple)) and len(lablaxis) > 1:
+        return [str(v) for v in lablaxis]
+    if isinstance(lablaxis, str) and lablaxis.startswith("["):
+        return _parse_list_string(lablaxis)
+    return None
+
+
+def _parse_list_string(s: str) -> list[str]:
+    try:
+        value = ast.literal_eval(s)
+        if isinstance(value, (list, tuple)):
+            return [str(v) for v in value]
+    except (ValueError, SyntaxError):
+        pass
+    stripped = s.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        stripped = stripped[1:-1]
+    return [part.strip() for part in stripped.split(",") if part.strip()]
+
+
+def _primary_label(meta: Mapping[str, Any]) -> Optional[str]:
+    lablaxis = meta.get("LABLAXIS")
+    if isinstance(lablaxis, str) and not lablaxis.startswith("["):
+        return lablaxis
+    if isinstance(lablaxis, (list, tuple)) and len(lablaxis) == 1:
+        return _as_str(lablaxis)
+    return _as_str(meta.get("FIELDNAM"))
+
+
+def _valid_range(meta: Mapping[str, Any]) -> Optional[tuple[float, float]]:
+    vmin = _as_float(meta.get("VALIDMIN"))
+    vmax = _as_float(meta.get("VALIDMAX"))
+    if vmin is None or vmax is None:
+        return None
+    return (vmin, vmax)
+
+
+def istp_metadata_to_hints(meta: Mapping[str, Any]) -> PlotHints:
+    """Translate a flat ISTP attribute dict to a PlotHints object.
+
+    The caller may attach a `_depend_1` sub-mapping holding the DEPEND_1
+    variable's own ISTP attributes — when present, it populates the y2 axis
+    hints (used by spectrogram plots for the energy/frequency axis).
+    """
+    if meta is None:
+        return PlotHints()
+
+    display = _display_type(meta.get("DISPLAY_TYPE"))
+    is_spectrogram = display == "spectrogram"
+
+    unit = _as_str(meta.get("UNITS"))
+    scale = _scale(meta.get("SCALETYP"))
+    label = _primary_label(meta)
+    valid = _valid_range(meta)
+    fill = _as_float(meta.get("FILLVAL"))
+
+    main_axis = AxisHints(label=label, unit=unit, scale=scale, valid_range=valid)
+
+    y = AxisHints()
+    z = AxisHints()
+    if is_spectrogram:
+        z = main_axis
+    else:
+        y = main_axis
+
+    y2 = AxisHints()
+    dep1 = meta.get("_depend_1")
+    if isinstance(dep1, Mapping):
+        y2 = AxisHints(
+            label=_primary_label(dep1),
+            unit=_as_str(dep1.get("UNITS")),
+            scale=_scale(dep1.get("SCALETYP")),
+            valid_range=_valid_range(dep1),
+        )
+
+    return PlotHints(
+        display_type=display,
+        y=y,
+        y2=y2,
+        z=z,
+        component_labels=_component_labels(meta),
+        fill_value=fill,
+    )

--- a/SciQLop/core/plot_hints.py
+++ b/SciQLop/core/plot_hints.py
@@ -1,0 +1,141 @@
+"""Declarative plot-configuration hints produced by providers from their own metadata.
+
+`PlotHints` is the single cross-provider vocabulary for axis labels, units,
+scales, valid ranges, fill values and component labels. Providers translate
+their native metadata (ISTP, HAPI, ...) into this model; `apply_plot_hints`
+consumes it at the plotting boundary and calls the SciQLopPlots axis setters.
+
+Pure data — no Qt, no SciQLopPlots import at module load time.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AxisHints(BaseModel):
+    label: Optional[str] = None
+    unit: Optional[str] = None
+    scale: Optional[Literal["linear", "log"]] = None
+    valid_range: Optional[tuple[float, float]] = None
+
+    def composed_label(self) -> Optional[str]:
+        if self.label and self.unit:
+            return f"{self.label} [{self.unit}]"
+        return self.label or (f"[{self.unit}]" if self.unit else None)
+
+
+class PlotHints(BaseModel):
+    display_type: Optional[Literal["line", "spectrogram"]] = None
+    x: AxisHints = Field(default_factory=AxisHints)
+    y: AxisHints = Field(default_factory=AxisHints)
+    y2: AxisHints = Field(default_factory=AxisHints)
+    z: AxisHints = Field(default_factory=AxisHints)
+    component_labels: Optional[list[str]] = None
+    fill_value: Optional[float] = None
+
+
+def _apply_axis(axis, hints: AxisHints) -> None:
+    if axis is None:
+        return
+    label = hints.composed_label()
+    if label is not None and hasattr(axis, "set_label"):
+        axis.set_label(label)
+    if hints.scale is not None and hasattr(axis, "set_log"):
+        axis.set_log(hints.scale == "log")
+
+
+def _get_axis(plot: Any, name: str):
+    getter = getattr(plot, name, None)
+    if getter is None:
+        return None
+    try:
+        return getter()
+    except Exception:
+        return None
+
+
+def _axis_is_empty(a: AxisHints) -> bool:
+    return a.label is None and a.unit is None and a.scale is None and a.valid_range is None
+
+
+def _first_non_empty_axis(entries, attr: str) -> AxisHints:
+    for h in entries:
+        a = getattr(h, attr)
+        if not _axis_is_empty(a):
+            return a
+    return AxisHints()
+
+
+def combine_hints(entries: list[PlotHints]) -> PlotHints:
+    """Merge hints from several products sharing one plot.
+
+    For the y axis (line plots), each entry contributes its composed label —
+    the final y label is the comma-joined list of unique per-product labels
+    ("Bt [nT], |B| [nT]"). Scale and valid_range take the first non-None.
+    For y2/z (spectrogram axes, one per plot in practice), the first entry
+    with a non-empty axis wins.
+    """
+    if not entries:
+        return PlotHints()
+
+    y_labels: list[str] = []
+    for h in entries:
+        cl = h.y.composed_label()
+        if cl and cl not in y_labels:
+            y_labels.append(cl)
+    y = AxisHints(
+        label=", ".join(y_labels) if y_labels else None,
+        scale=next((h.y.scale for h in entries if h.y.scale), None),
+        valid_range=next((h.y.valid_range for h in entries if h.y.valid_range), None),
+    )
+
+    return PlotHints(
+        display_type=next((h.display_type for h in entries if h.display_type), None),
+        y=y,
+        y2=_first_non_empty_axis(entries, "y2"),
+        z=_first_non_empty_axis(entries, "z"),
+        x=_first_non_empty_axis(entries, "x"),
+    )
+
+
+def _merge_axis(base: AxisHints, extra: AxisHints) -> AxisHints:
+    return AxisHints(
+        label=base.label or extra.label,
+        unit=base.unit or extra.unit,
+        scale=base.scale or extra.scale,
+        valid_range=base.valid_range or extra.valid_range,
+    )
+
+
+def merge_hints(base: PlotHints, extra: PlotHints) -> PlotHints:
+    """Fill fields in `base` from `extra` only where `base` is empty.
+
+    Used to refine inventory-time hints with post-fetch hints derived from the
+    actual data variable — post-fetch never overwrites a value the inventory
+    already provided.
+    """
+    return PlotHints(
+        display_type=base.display_type or extra.display_type,
+        x=_merge_axis(base.x, extra.x),
+        y=_merge_axis(base.y, extra.y),
+        y2=_merge_axis(base.y2, extra.y2),
+        z=_merge_axis(base.z, extra.z),
+        component_labels=base.component_labels or extra.component_labels,
+        fill_value=base.fill_value if base.fill_value is not None else extra.fill_value,
+    )
+
+
+def apply_plot_hints(plot: Any, hints: PlotHints) -> None:
+    """Apply a `PlotHints` object to a SciQLopPlot-like plot instance.
+
+    Only writes fields that are set. Safe to call with an empty `PlotHints()`.
+    Tolerates plots that don't expose a given axis (returns silently).
+    """
+    if plot is None:
+        return
+    _apply_axis(_get_axis(plot, "y_axis"), hints.y)
+    _apply_axis(_get_axis(plot, "y2_axis"), hints.y2)
+    _apply_axis(_get_axis(plot, "z_axis"), hints.z)
+    _apply_axis(_get_axis(plot, "x_axis"), hints.x)

--- a/SciQLop/core/speasy_hints.py
+++ b/SciQLop/core/speasy_hints.py
@@ -1,0 +1,69 @@
+"""Flatten a SpeasyVariable's direct attributes into an ISTP-style meta dict.
+
+Pure-Python helper — no Qt, no SciQLopPlots, no speasy import at module load
+time (the `variable` argument is duck-typed). Lets providers like AMDA that
+don't populate the full ISTP attribute set still produce labeled plots, by
+using `variable.name`, `variable.unit`, `variable.columns`, `variable.axes[i]`
+as fallbacks. Existing meta entries always win — this never overwrites
+upstream keys.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any, Dict
+
+
+def _first_scalar(value: Any) -> Any:
+    while hasattr(value, "__len__") and not isinstance(value, str):
+        try:
+            if len(value) == 0:
+                return None
+            value = value[0]
+        except (TypeError, IndexError):
+            return None
+    return value
+
+
+def _is_nan(value: Any) -> bool:
+    try:
+        return isinstance(value, float) and math.isnan(value)
+    except TypeError:
+        return False
+
+
+def _axis_as_istp_meta(axis) -> Dict[str, Any]:
+    meta = dict(axis.meta) if axis.meta else {}
+    if axis.unit:
+        meta.setdefault("UNITS", axis.unit)
+    if axis.name:
+        meta.setdefault("LABLAXIS", axis.name)
+    return meta
+
+
+def variable_as_istp_meta(variable) -> Dict[str, Any]:
+    meta: Dict[str, Any] = dict(variable.meta or {})
+    if variable.unit:
+        meta.setdefault("UNITS", variable.unit)
+    if variable.name:
+        meta.setdefault("LABLAXIS", variable.name)
+        meta.setdefault("FIELDNAM", variable.name)
+    if variable.columns:
+        meta.setdefault("LABL_PTR_1", list(variable.columns))
+    vr = getattr(variable, "valid_range", None)
+    if vr is not None:
+        try:
+            vmin, vmax = vr
+            vmin = _first_scalar(vmin)
+            vmax = _first_scalar(vmax)
+            if vmin is not None:
+                meta.setdefault("VALIDMIN", vmin)
+            if vmax is not None:
+                meta.setdefault("VALIDMAX", vmax)
+        except (TypeError, ValueError):
+            pass
+    fv = _first_scalar(getattr(variable, "fill_value", None))
+    if fv is not None and not _is_nan(fv):
+        meta.setdefault("FILLVAL", fv)
+    if len(variable.axes) > 1:
+        meta["_depend_1"] = _axis_as_istp_meta(variable.axes[1])
+    return meta

--- a/SciQLop/plugins/speasy_provider/speasy_provider.py
+++ b/SciQLop/plugins/speasy_provider/speasy_provider.py
@@ -13,6 +13,7 @@ from SciQLop.core.enums import ParameterType, GraphType
 from SciQLop.components.plotting.backend.data_provider import DataProvider, DataOrder
 from SciQLop.core.plot_hints import PlotHints
 from SciQLop.core.istp_hints import istp_metadata_to_hints
+from SciQLop.core.speasy_hints import variable_as_istp_meta
 from SciQLop import __version__ as sciqlop_version
 from SciQLopPlots import ProductsModel, ProductsModelNode, ProductsModelNodeType
 
@@ -217,16 +218,9 @@ class SpeasyPlugin(DataProvider):
 
     def plot_hints_from_variable(self, node: ProductsModelNode, variable: SpeasyVariable) -> PlotHints:
         try:
-            meta = dict(variable.meta or {})
-            if len(variable.axes) > 1:
-                axis = variable.axes[1]
-                meta["_depend_1"] = {
-                    **(dict(axis.meta) if axis.meta else {}),
-                    "UNITS": axis.unit,
-                    "LABLAXIS": axis.name,
-                }
-            if variable.unit and "UNITS" not in meta:
-                meta["UNITS"] = variable.unit
+            meta = variable_as_istp_meta(variable)
+            if self.graph_type(node) == GraphType.ColorMap:
+                meta.setdefault("DISPLAY_TYPE", "spectrogram")
             return istp_metadata_to_hints(meta)
         except Exception:
             log.debug("plot_hints_from_variable failed for %s", node, exc_info=True)

--- a/SciQLop/plugins/speasy_provider/speasy_provider.py
+++ b/SciQLop/plugins/speasy_provider/speasy_provider.py
@@ -11,6 +11,8 @@ from SciQLop.components.theming import register_icon, get_icon
 from SciQLop.components import sciqlop_logging
 from SciQLop.core.enums import ParameterType, GraphType
 from SciQLop.components.plotting.backend.data_provider import DataProvider, DataOrder
+from SciQLop.core.plot_hints import PlotHints
+from SciQLop.core.istp_hints import istp_metadata_to_hints
 from SciQLop import __version__ as sciqlop_version
 from SciQLopPlots import ProductsModel, ProductsModelNode, ProductsModelNodeType
 
@@ -112,9 +114,14 @@ def data_serie_type(param: ParameterIndex):
 def get_node_meta(node):
     meta = {}
     for name, child in node.__dict__.items():
-        if isinstance(child, str):
-            if not name.startswith("_"):
-                meta[name] = child
+        if name.startswith("_"):
+            continue
+        if isinstance(child, (str, int, float)):
+            meta[name] = child
+        elif isinstance(child, (list, tuple)) and all(
+            isinstance(v, (str, int, float)) for v in child
+        ):
+            meta[name] = list(child)
     return meta
 
 
@@ -200,6 +207,30 @@ class SpeasyPlugin(DataProvider):
         if param_type == ParameterType.Spectrogram:
             return GraphType.ColorMap
         return GraphType.Unknown
+
+    def plot_hints(self, node: ProductsModelNode) -> PlotHints:
+        try:
+            return istp_metadata_to_hints(node.metadata())
+        except Exception:
+            log.debug("plot_hints failed for %s", node, exc_info=True)
+            return PlotHints()
+
+    def plot_hints_from_variable(self, node: ProductsModelNode, variable: SpeasyVariable) -> PlotHints:
+        try:
+            meta = dict(variable.meta or {})
+            if len(variable.axes) > 1:
+                axis = variable.axes[1]
+                meta["_depend_1"] = {
+                    **(dict(axis.meta) if axis.meta else {}),
+                    "UNITS": axis.unit,
+                    "LABLAXIS": axis.name,
+                }
+            if variable.unit and "UNITS" not in meta:
+                meta["UNITS"] = variable.unit
+            return istp_metadata_to_hints(meta)
+        except Exception:
+            log.debug("plot_hints_from_variable failed for %s", node, exc_info=True)
+            return PlotHints()
 
 
 def load(*args):

--- a/tests/test_istp_hints.py
+++ b/tests/test_istp_hints.py
@@ -1,0 +1,129 @@
+"""Pure-Python tests for the ISTP → PlotHints adapter.
+
+No Qt, no SciQLopPlots — these exercise the declarative translation only.
+"""
+from SciQLop.core.istp_hints import istp_metadata_to_hints
+from SciQLop.core.plot_hints import PlotHints
+
+
+def test_empty_meta():
+    h = istp_metadata_to_hints({})
+    assert h == PlotHints()
+
+
+def test_none_meta():
+    assert istp_metadata_to_hints(None) == PlotHints()
+
+
+def test_scalar_line_basic():
+    h = istp_metadata_to_hints({
+        "UNITS": "nT",
+        "SCALETYP": "linear",
+        "FIELDNAM": "Bt",
+    })
+    assert h.display_type is None
+    assert h.y.unit == "nT"
+    assert h.y.scale == "linear"
+    assert h.y.label == "Bt"
+    assert h.y.composed_label() == "Bt [nT]"
+    assert h.z == PlotHints().z
+
+
+def test_lablaxis_primary_label():
+    h = istp_metadata_to_hints({"UNITS": "nT", "LABLAXIS": "|B|"})
+    assert h.y.label == "|B|"
+
+
+def test_log_scale_variants():
+    assert istp_metadata_to_hints({"SCALETYP": "log"}).y.scale == "log"
+    assert istp_metadata_to_hints({"SCALETYP": "LinearScale"}).y.scale == "linear"
+    assert istp_metadata_to_hints({"SCALETYP": "nope"}).y.scale is None
+
+
+def test_spectrogram_routes_to_z():
+    h = istp_metadata_to_hints({
+        "DISPLAY_TYPE": "spectrogram",
+        "UNITS": "1/(cm^2 s sr eV)",
+        "SCALETYP": "log",
+        "FIELDNAM": "flux",
+    })
+    assert h.display_type == "spectrogram"
+    assert h.y.unit is None
+    assert h.z.unit == "1/(cm^2 s sr eV)"
+    assert h.z.scale == "log"
+    assert h.z.label == "flux"
+
+
+def test_display_type_line_alias():
+    assert istp_metadata_to_hints({"DISPLAY_TYPE": "time_series"}).display_type == "line"
+    assert istp_metadata_to_hints({"DISPLAY_TYPE": "timeseries"}).display_type == "line"
+
+
+def test_valid_range():
+    h = istp_metadata_to_hints({"VALIDMIN": 0.0, "VALIDMAX": 100.0})
+    assert h.y.valid_range == (0.0, 100.0)
+
+
+def test_valid_range_list_form():
+    h = istp_metadata_to_hints({"VALIDMIN": [-1e31], "VALIDMAX": [100.0]})
+    assert h.y.valid_range == (-1e31, 100.0)
+
+
+def test_fillval_scalar():
+    assert istp_metadata_to_hints({"FILLVAL": -1e31}).fill_value == -1e31
+
+
+def test_fillval_list():
+    assert istp_metadata_to_hints({"FILLVAL": [-1e31]}).fill_value == -1e31
+
+
+def test_component_labels_labl_ptr_list():
+    h = istp_metadata_to_hints({"LABL_PTR_1": ["Bx", "By", "Bz"]})
+    assert h.component_labels == ["Bx", "By", "Bz"]
+
+
+def test_component_labels_labl_ptr_python_literal():
+    h = istp_metadata_to_hints({"LABL_PTR_1": "['Bx','By','Bz']"})
+    assert h.component_labels == ["Bx", "By", "Bz"]
+
+
+def test_component_labels_labl_ptr_comma_string():
+    h = istp_metadata_to_hints({"LABL_PTR_1": "Bx,By,Bz"})
+    assert h.component_labels == ["Bx", "By", "Bz"]
+
+
+def test_component_labels_from_lablaxis_bracketed():
+    h = istp_metadata_to_hints({"LABLAXIS": "[Bx,By,Bz]"})
+    assert h.component_labels == ["Bx", "By", "Bz"]
+
+
+def test_depend_1_populates_y2():
+    h = istp_metadata_to_hints({
+        "DISPLAY_TYPE": "spectrogram",
+        "UNITS": "counts",
+        "_depend_1": {
+            "UNITS": "eV",
+            "SCALETYP": "log",
+            "LABLAXIS": "Energy",
+        },
+    })
+    assert h.y2.unit == "eV"
+    assert h.y2.scale == "log"
+    assert h.y2.label == "Energy"
+    assert h.y2.composed_label() == "Energy [eV]"
+
+
+def test_depend_1_missing_is_empty_y2():
+    h = istp_metadata_to_hints({"UNITS": "nT"})
+    assert h.y2.unit is None
+    assert h.y2.label is None
+
+
+def test_units_without_label():
+    h = istp_metadata_to_hints({"UNITS": "nT"})
+    assert h.y.composed_label() == "[nT]"
+
+
+def test_missing_validmin_only():
+    h = istp_metadata_to_hints({"VALIDMIN": 0.0})
+    assert h.y.valid_range is None

--- a/tests/test_plot_hints_apply.py
+++ b/tests/test_plot_hints_apply.py
@@ -1,0 +1,79 @@
+"""Tests for apply_plot_hints against a mock plot object.
+
+We don't need a real SciQLopPlot here — the contract is "call the right
+setters with the right values." A minimal mock captures that exactly and
+keeps the test Qt-free.
+"""
+from unittest.mock import MagicMock
+
+from SciQLop.core.plot_hints import AxisHints, PlotHints, apply_plot_hints
+
+
+def _make_plot():
+    plot = MagicMock()
+    # Each axis getter returns a fresh MagicMock so set_label/set_log land there.
+    plot.y_axis.return_value = MagicMock()
+    plot.y2_axis.return_value = MagicMock()
+    plot.z_axis.return_value = MagicMock()
+    plot.x_axis.return_value = MagicMock()
+    return plot
+
+
+def test_empty_hints_is_noop():
+    plot = _make_plot()
+    apply_plot_hints(plot, PlotHints())
+    plot.y_axis.return_value.set_label.assert_not_called()
+    plot.y_axis.return_value.set_log.assert_not_called()
+    plot.z_axis.return_value.set_label.assert_not_called()
+
+
+def test_line_hints_sets_y():
+    plot = _make_plot()
+    hints = PlotHints(y=AxisHints(label="Bt", unit="nT", scale="linear"))
+    apply_plot_hints(plot, hints)
+    plot.y_axis.return_value.set_label.assert_called_once_with("Bt [nT]")
+    plot.y_axis.return_value.set_log.assert_called_once_with(False)
+
+
+def test_log_scale():
+    plot = _make_plot()
+    hints = PlotHints(y=AxisHints(unit="counts", scale="log"))
+    apply_plot_hints(plot, hints)
+    plot.y_axis.return_value.set_log.assert_called_once_with(True)
+    plot.y_axis.return_value.set_label.assert_called_once_with("[counts]")
+
+
+def test_spectrogram_hints_sets_y2_and_z():
+    plot = _make_plot()
+    hints = PlotHints(
+        display_type="spectrogram",
+        y2=AxisHints(label="Energy", unit="eV", scale="log"),
+        z=AxisHints(label="flux", unit="1/(cm^2 s sr eV)", scale="log"),
+    )
+    apply_plot_hints(plot, hints)
+    plot.y2_axis.return_value.set_label.assert_called_once_with("Energy [eV]")
+    plot.y2_axis.return_value.set_log.assert_called_once_with(True)
+    plot.z_axis.return_value.set_label.assert_called_once_with("flux [1/(cm^2 s sr eV)]")
+    plot.z_axis.return_value.set_log.assert_called_once_with(True)
+
+
+def test_none_plot_tolerated():
+    apply_plot_hints(None, PlotHints(y=AxisHints(label="x")))
+
+
+def test_scale_none_does_not_call_set_log():
+    plot = _make_plot()
+    hints = PlotHints(y=AxisHints(label="Bt"))
+    apply_plot_hints(plot, hints)
+    plot.y_axis.return_value.set_log.assert_not_called()
+
+
+def test_missing_axis_getter_is_tolerated():
+    plot = MagicMock(spec=["y_axis"])
+    plot.y_axis.return_value = MagicMock()
+    hints = PlotHints(
+        y=AxisHints(label="Bt", scale="linear"),
+        z=AxisHints(label="flux"),
+    )
+    apply_plot_hints(plot, hints)
+    plot.y_axis.return_value.set_label.assert_called_once_with("Bt")

--- a/tests/test_plot_hints_merge.py
+++ b/tests/test_plot_hints_merge.py
@@ -1,0 +1,119 @@
+"""Tests for merge_hints and combine_hints."""
+from SciQLop.core.plot_hints import AxisHints, PlotHints, combine_hints, merge_hints
+
+
+def test_merge_empty_base_takes_extra():
+    base = PlotHints()
+    extra = PlotHints(y=AxisHints(label="Bt", unit="nT", scale="linear"))
+    merged = merge_hints(base, extra)
+    assert merged.y.label == "Bt"
+    assert merged.y.unit == "nT"
+    assert merged.y.scale == "linear"
+
+
+def test_merge_base_wins_over_extra():
+    base = PlotHints(y=AxisHints(label="from_inventory", unit="nT"))
+    extra = PlotHints(y=AxisHints(label="from_variable", unit="T"))
+    merged = merge_hints(base, extra)
+    assert merged.y.label == "from_inventory"
+    assert merged.y.unit == "nT"
+
+
+def test_merge_fills_only_missing_fields():
+    base = PlotHints(y=AxisHints(label="Bt"))
+    extra = PlotHints(y=AxisHints(label="ignored", unit="nT", scale="linear"))
+    merged = merge_hints(base, extra)
+    assert merged.y.label == "Bt"
+    assert merged.y.unit == "nT"
+    assert merged.y.scale == "linear"
+
+
+def test_merge_y2_from_extra():
+    base = PlotHints(display_type="spectrogram", z=AxisHints(label="flux"))
+    extra = PlotHints(y2=AxisHints(label="Energy", unit="eV", scale="log"))
+    merged = merge_hints(base, extra)
+    assert merged.y2.label == "Energy"
+    assert merged.y2.unit == "eV"
+    assert merged.y2.scale == "log"
+    assert merged.z.label == "flux"
+    assert merged.display_type == "spectrogram"
+
+
+def test_merge_component_labels_base_wins():
+    base = PlotHints(component_labels=["a", "b"])
+    extra = PlotHints(component_labels=["x", "y", "z"])
+    assert merge_hints(base, extra).component_labels == ["a", "b"]
+
+
+def test_merge_component_labels_from_extra_when_base_none():
+    base = PlotHints()
+    extra = PlotHints(component_labels=["Bx", "By", "Bz"])
+    assert merge_hints(base, extra).component_labels == ["Bx", "By", "Bz"]
+
+
+def test_merge_fill_value_base_wins():
+    base = PlotHints(fill_value=-1e31)
+    extra = PlotHints(fill_value=0.0)
+    assert merge_hints(base, extra).fill_value == -1e31
+
+
+def test_merge_fill_value_from_extra():
+    base = PlotHints()
+    extra = PlotHints(fill_value=-1e31)
+    assert merge_hints(base, extra).fill_value == -1e31
+
+
+def test_combine_empty_list_is_empty():
+    assert combine_hints([]) == PlotHints()
+
+
+def test_combine_single_entry_y_label():
+    h = PlotHints(y=AxisHints(label="Bt", unit="nT", scale="linear"))
+    combined = combine_hints([h])
+    assert combined.y.label == "Bt [nT]"
+    assert combined.y.scale == "linear"
+
+
+def test_combine_two_line_products_joins_labels():
+    h1 = PlotHints(y=AxisHints(label="Bt", unit="nT"))
+    h2 = PlotHints(y=AxisHints(label="|B|", unit="nT"))
+    combined = combine_hints([h1, h2])
+    assert combined.y.label == "Bt [nT], |B| [nT]"
+
+
+def test_combine_deduplicates_identical_labels():
+    h1 = PlotHints(y=AxisHints(label="Bt", unit="nT"))
+    h2 = PlotHints(y=AxisHints(label="Bt", unit="nT"))
+    assert combine_hints([h1, h2]).y.label == "Bt [nT]"
+
+
+def test_combine_first_scale_wins():
+    h1 = PlotHints(y=AxisHints(label="a", scale="linear"))
+    h2 = PlotHints(y=AxisHints(label="b", scale="log"))
+    assert combine_hints([h1, h2]).y.scale == "linear"
+
+
+def test_combine_skips_entries_without_y_label():
+    h1 = PlotHints()
+    h2 = PlotHints(y=AxisHints(label="Bt", unit="nT"))
+    assert combine_hints([h1, h2]).y.label == "Bt [nT]"
+
+
+def test_combine_spectrogram_plus_line_keeps_z_and_y():
+    line = PlotHints(y=AxisHints(label="Bt", unit="nT"))
+    spec = PlotHints(
+        display_type="spectrogram",
+        y2=AxisHints(label="Energy", unit="eV", scale="log"),
+        z=AxisHints(label="flux", scale="log"),
+    )
+    combined = combine_hints([line, spec])
+    assert combined.y.label == "Bt [nT]"
+    assert combined.y2.label == "Energy"
+    assert combined.z.label == "flux"
+    assert combined.display_type == "spectrogram"
+
+
+def test_combine_first_non_empty_y2_wins():
+    h1 = PlotHints(y2=AxisHints(label="E1", unit="eV"))
+    h2 = PlotHints(y2=AxisHints(label="E2", unit="keV"))
+    assert combine_hints([h1, h2]).y2.label == "E1"

--- a/tests/test_speasy_variable_meta.py
+++ b/tests/test_speasy_variable_meta.py
@@ -1,0 +1,85 @@
+"""Tests for _variable_as_istp_meta — SpeasyVariable → ISTP meta fallback."""
+from types import SimpleNamespace
+
+from SciQLop.core.speasy_hints import variable_as_istp_meta as _variable_as_istp_meta
+
+
+def _axis(name=None, unit=None, meta=None):
+    return SimpleNamespace(name=name, unit=unit, meta=meta or {})
+
+
+def _var(**kw):
+    defaults = dict(
+        meta={}, name=None, unit=None, columns=None,
+        valid_range=None, fill_value=None, axes=[_axis(name="time", unit="ns")],
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def test_empty_meta_uses_fallbacks():
+    v = _var(name="imf", unit="nT", columns=["bx", "by", "bz"])
+    meta = _variable_as_istp_meta(v)
+    assert meta["UNITS"] == "nT"
+    assert meta["LABLAXIS"] == "imf"
+    assert meta["FIELDNAM"] == "imf"
+    assert meta["LABL_PTR_1"] == ["bx", "by", "bz"]
+
+
+def test_existing_meta_wins_over_fallbacks():
+    v = _var(
+        meta={"UNITS": "T", "LABLAXIS": "from_istp"},
+        name="imf", unit="nT",
+    )
+    meta = _variable_as_istp_meta(v)
+    assert meta["UNITS"] == "T"
+    assert meta["LABLAXIS"] == "from_istp"
+    assert meta["FIELDNAM"] == "imf"
+
+
+def test_valid_range_list_tuples_flattened():
+    v = _var(valid_range=([-1e31], [1e31]))
+    meta = _variable_as_istp_meta(v)
+    assert meta["VALIDMIN"] == -1e31
+    assert meta["VALIDMAX"] == 1e31
+
+
+def test_nan_fill_value_skipped():
+    v = _var(fill_value=[float("nan")])
+    assert "FILLVAL" not in _variable_as_istp_meta(v)
+
+
+def test_scalar_fill_value_kept():
+    v = _var(fill_value=-1e31)
+    assert _variable_as_istp_meta(v)["FILLVAL"] == -1e31
+
+
+def test_depend_1_built_from_axes():
+    v = _var(
+        axes=[
+            _axis(name="time", unit="ns"),
+            _axis(name="energy", unit="eV", meta={"SCALETYP": "log"}),
+        ],
+    )
+    meta = _variable_as_istp_meta(v)
+    d1 = meta["_depend_1"]
+    assert d1["UNITS"] == "eV"
+    assert d1["LABLAXIS"] == "energy"
+    assert d1["SCALETYP"] == "log"
+
+
+def test_depend_1_meta_wins_over_axis_attrs():
+    v = _var(
+        axes=[
+            _axis(name="time", unit="ns"),
+            _axis(name="ignored", unit="ignored", meta={"UNITS": "keV", "LABLAXIS": "E"}),
+        ],
+    )
+    d1 = _variable_as_istp_meta(v)["_depend_1"]
+    assert d1["UNITS"] == "keV"
+    assert d1["LABLAXIS"] == "E"
+
+
+def test_no_depend_1_when_single_axis():
+    v = _var(axes=[_axis(name="time", unit="ns")])
+    assert "_depend_1" not in _variable_as_istp_meta(v)


### PR DESCRIPTION
## Summary
- New declarative `PlotHints` / `AxisHints` data model and `apply_plot_hints` boundary, produced by per-provider translators
- Shared ISTP adapter `istp_metadata_to_hints` in SciQLop core, consumed by both the speasy provider (tree-node metadata) and cdf_workbench (CDF attributes)
- Post-fetch refinement via `DataProvider.plot_hints_from_variable`: the speasy override flattens `SpeasyVariable.{name,unit,columns,valid_range,fill_value,axes[1]}` as ISTP-keyed fallbacks so providers like AMDA produce labeled axes even when upstream meta is sparse
- Multi-product plots: per-graph hints accumulate in a registry keyed by the plot's C++ pointer; y-axis label becomes the comma-joined composition of each product's label, auto-rebuilds when a graph is removed via `QObject.destroyed`

## Test plan
- [x] `pytest tests/test_istp_hints.py tests/test_plot_hints_apply.py tests/test_plot_hints_merge.py tests/test_speasy_variable_meta.py` — 34 new pure-Python tests
- [x] `pytest tests/test_catalog_plot_integration.py tests/test_plot_pure_logic.py tests/test_panel_template_integration.py` — plot-path tests green
- [x] cdf_workbench preview/file_view test suite (separate PR in the plugins repo)
- [ ] Manual: drag a speasy scalar product onto a panel, check y label
- [ ] Manual: drag two line products onto the same plot, verify the label is the comma-joined composition
- [ ] Manual: delete one graph, verify the label shrinks back
- [ ] Manual: drag an AMDA spectrogram, verify y2 (energy) and z (flux) are labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)