### PR TITLE
feat(agents): multi-backend agent chat framework

### DIFF
--- a/SciQLop/components/agents/__init__.py
+++ b/SciQLop/components/agents/__init__.py
@@ -1,0 +1,29 @@
+"""Agent-agnostic primitives for LLM chat docks embedded in SciQLop."""
+from .backend import (
+    AgentBackend,
+    BackendContext,
+    ConfirmCallback,
+    SessionEntry,
+    StreamBlock,
+)
+from .chat_dock import AgentChatDock, ensure_agent_dock
+from .registry import (
+    available_backends,
+    create_backend,
+    register_agent_backend,
+    unregister_agent_backend,
+)
+
+__all__ = [
+    "AgentBackend",
+    "AgentChatDock",
+    "BackendContext",
+    "ConfirmCallback",
+    "SessionEntry",
+    "StreamBlock",
+    "available_backends",
+    "create_backend",
+    "ensure_agent_dock",
+    "register_agent_backend",
+    "unregister_agent_backend",
+]

--- a/SciQLop/components/agents/backend.py
+++ b/SciQLop/components/agents/backend.py
@@ -1,0 +1,73 @@
+"""Agent backend protocol — contract a chat-capable plugin implements."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    runtime_checkable,
+)
+
+from .chat import ChatMessage, ImageBlock, TextBlock
+
+StreamBlock = TextBlock | ImageBlock
+ConfirmCallback = Callable[[str, dict], Awaitable[bool]]
+
+
+@dataclass
+class BackendContext:
+    main_window: Any
+    tools: List[dict]
+    tempdir: Path
+    confirm_cb: ConfirmCallback
+    allow_writes: bool = False
+
+
+@dataclass
+class SessionEntry:
+    id: str
+    label: str
+    mtime: float
+
+
+@runtime_checkable
+class AgentBackend(Protocol):
+    display_name: str
+    model_choices: List[Tuple[str, Optional[str]]]
+    supports_sessions: bool
+
+    def ask(
+        self, prompt: str, image_paths: Optional[List[str]] = None
+    ) -> AsyncIterator[StreamBlock]:
+        ...
+
+    async def reset(self) -> None:
+        ...
+
+    async def cancel(self) -> None:
+        ...
+
+    async def resume(self, session_id: str) -> None:
+        ...
+
+    async def set_model(self, model: Optional[str]) -> None:
+        ...
+
+    def set_allow_writes(self, allow: bool) -> None:
+        ...
+
+    async def list_slash_commands(self) -> List[str]:
+        ...
+
+    def list_sessions(self) -> List[SessionEntry]:
+        ...
+
+    def load_session(self, session_id: str, image_tempdir: Path) -> List[ChatMessage]:
+        ...

--- a/SciQLop/components/agents/chat/__init__.py
+++ b/SciQLop/components/agents/chat/__init__.py
@@ -1,0 +1,23 @@
+"""Chat UI primitives: typed message/block model and Qt widgets.
+
+`ChatMessage`, `TextBlock`, `ImageBlock` are the data model shared across
+backends. `TranscriptView` renders them with coalesced markdown updates;
+`ChatInput` handles image paste into a dock-owned tempdir.
+"""
+from ._images import write_b64_image
+from .view import (
+    ChatInput,
+    ChatMessage,
+    ImageBlock,
+    TextBlock,
+    TranscriptView,
+)
+
+__all__ = [
+    "ChatInput",
+    "ChatMessage",
+    "ImageBlock",
+    "TextBlock",
+    "TranscriptView",
+    "write_b64_image",
+]

--- a/SciQLop/components/agents/chat/_images.py
+++ b/SciQLop/components/agents/chat/_images.py
@@ -1,0 +1,24 @@
+"""Shared base64-image → tempfile helper."""
+from __future__ import annotations
+
+import base64
+import uuid
+from pathlib import Path
+from typing import Optional
+
+
+def write_b64_image(data: Optional[str], mime: str, tempdir: Path, prefix: str = "img") -> Optional[str]:
+    if not data:
+        return None
+    if "png" in mime:
+        ext = ".png"
+    elif "jpeg" in mime or "jpg" in mime:
+        ext = ".jpg"
+    else:
+        ext = ".bin"
+    path = Path(tempdir) / f"{prefix}_{uuid.uuid4().hex}{ext}"
+    try:
+        path.write_bytes(base64.b64decode(data))
+    except (ValueError, OSError):
+        return None
+    return str(path)

--- a/SciQLop/components/agents/chat/view.py
+++ b/SciQLop/components/agents/chat/view.py
@@ -1,0 +1,260 @@
+"""Rich chat widgets: markdown transcript view and image-paste-capable input.
+
+Agent-agnostic: the assistant label and input placeholder can be set by the
+dock once it knows which backend is active.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Literal, Union
+
+from PySide6.QtCore import QMimeData, QStringListModel, Qt, QTimer, QUrl
+from PySide6.QtGui import (
+    QImage,
+    QKeyEvent,
+    QTextCursor,
+    QTextDocument,
+    QTextDocumentFragment,
+    QTextImageFormat,
+)
+from PySide6.QtWidgets import QCompleter, QTextBrowser, QTextEdit
+
+
+@dataclass
+class TextBlock:
+    text: str = ""
+
+
+@dataclass
+class ImageBlock:
+    path: str
+
+
+ContentBlock = Union[TextBlock, ImageBlock]
+
+
+@dataclass
+class ChatMessage:
+    role: Literal["user", "assistant", "error"]
+    blocks: List[ContentBlock] = field(default_factory=list)
+    done: bool = False
+
+
+_DEFAULT_ROLE_LABEL = {"user": "You", "assistant": "Assistant", "error": "Error"}
+_ROLE_COLOR = {"user": "#3d6ab0", "assistant": "#2a7a3c", "error": "#a33"}
+
+_RENDER_INTERVAL_MS = 80
+
+
+class TranscriptView(QTextBrowser):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setOpenExternalLinks(False)
+        self.setOpenLinks(False)
+        self.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.LinksAccessibleByMouse
+        )
+        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self._image_max_width_px = 720
+        self._role_labels = dict(_DEFAULT_ROLE_LABEL)
+        self._pending_messages: List[ChatMessage] | None = None
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.setInterval(_RENDER_INTERVAL_MS)
+        self._render_timer.timeout.connect(self._flush)
+
+    def set_assistant_label(self, label: str) -> None:
+        self._role_labels["assistant"] = label or "Assistant"
+
+    def render_messages(self, messages: List[ChatMessage]) -> None:
+        self._pending_messages = messages
+        if not self._render_timer.isActive():
+            self._render_timer.start()
+
+    def flush_now(self) -> None:
+        self._render_timer.stop()
+        self._flush()
+
+    def _flush(self) -> None:
+        messages = self._pending_messages
+        if messages is None:
+            return
+        self._pending_messages = None
+        doc = QTextDocument()
+        doc.setDefaultStyleSheet(
+            "h4 { margin-top: 14px; margin-bottom: 4px; }"
+            "p { margin-top: 4px; margin-bottom: 4px; }"
+            "pre { background: #eee; padding: 4px; }"
+        )
+        cursor = QTextCursor(doc)
+
+        for i, msg in enumerate(messages):
+            if i > 0:
+                cursor.insertBlock()
+            self._write_message(cursor, doc, msg)
+
+        self.setDocument(doc)
+        self._scroll_to_end()
+
+    def _write_message(self, cursor: QTextCursor, doc: QTextDocument, msg: ChatMessage) -> None:
+        label = self._role_labels.get(msg.role, msg.role)
+        color = _ROLE_COLOR.get(msg.role, "#444")
+        cursor.insertHtml(f'<h4 style="color:{color}">{label}</h4>')
+
+        for block in msg.blocks:
+            if isinstance(block, TextBlock):
+                if block.text:
+                    self._insert_markdown(cursor, block.text)
+            elif isinstance(block, ImageBlock):
+                self._insert_image(cursor, doc, block.path)
+
+    @staticmethod
+    def _insert_markdown(cursor: QTextCursor, markdown: str) -> None:
+        scratch = QTextDocument()
+        scratch.setMarkdown(markdown)
+        cursor.insertBlock()
+        cursor.insertFragment(QTextDocumentFragment(scratch))
+
+    def _insert_image(self, cursor: QTextCursor, doc: QTextDocument, path: str) -> None:
+        image = QImage(path)
+        if image.isNull():
+            cursor.insertHtml(f"<p><i>[missing image: {path}]</i></p>")
+            return
+        if image.width() > self._image_max_width_px:
+            image = image.scaledToWidth(
+                self._image_max_width_px, Qt.TransformationMode.SmoothTransformation
+            )
+        resource_url = QUrl(f"sciqlop-chat://{_uuid.uuid4().hex}")
+        doc.addResource(QTextDocument.ResourceType.ImageResource, resource_url, image)
+        fmt = QTextImageFormat()
+        fmt.setName(resource_url.toString())
+        cursor.insertBlock()
+        cursor.insertImage(fmt)
+        cursor.insertBlock()
+
+    def _scroll_to_end(self) -> None:
+        bar = self.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
+
+class ChatInput(QTextEdit):
+    _DEFAULT_PLACEHOLDER = (
+        "Ask about the current SciQLop state… "
+        "(Ctrl+V to paste images, / for commands)"
+    )
+
+    def __init__(self, tempdir: Path, parent=None):
+        super().__init__(parent)
+        self._tempdir = Path(tempdir)
+        self._tempdir.mkdir(parents=True, exist_ok=True)
+        self._pending_images: List[str] = []
+        self.setPlaceholderText(self._DEFAULT_PLACEHOLDER)
+        self.setAcceptRichText(False)
+
+        self._completer_model = QStringListModel([], self)
+        self._completer = QCompleter(self._completer_model, self)
+        self._completer.setWidget(self)
+        self._completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
+        self._completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._completer.activated.connect(self._insert_completion)
+
+    def set_completions(self, words: List[str]) -> None:
+        self._completer_model.setStringList(sorted(set(words)))
+
+    def _current_slash_token(self) -> str:
+        cursor = self.textCursor()
+        cursor.select(QTextCursor.SelectionType.LineUnderCursor)
+        line = cursor.selectedText()
+        stripped = line.lstrip()
+        if not stripped.startswith("/"):
+            return ""
+        token = stripped.split(" ", 1)[0]
+        return token
+
+    def _insert_completion(self, completion: str) -> None:
+        cursor = self.textCursor()
+        token = self._current_slash_token()
+        if not token:
+            cursor.insertText(completion + " ")
+            return
+        for _ in range(len(token)):
+            cursor.deletePreviousChar()
+        cursor.insertText(completion + " ")
+        self.setTextCursor(cursor)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        popup = self._completer.popup()
+        if popup and popup.isVisible():
+            if event.key() in (
+                Qt.Key.Key_Return,
+                Qt.Key.Key_Enter,
+                Qt.Key.Key_Tab,
+                Qt.Key.Key_Escape,
+                Qt.Key.Key_Up,
+                Qt.Key.Key_Down,
+            ):
+                event.ignore()
+                return
+        super().keyPressEvent(event)
+        token = self._current_slash_token()
+        if len(token) >= 1 and self._completer_model.rowCount() > 0:
+            self._completer.setCompletionPrefix(token)
+            rect = self.cursorRect()
+            rect.setWidth(
+                self._completer.popup().sizeHintForColumn(0)
+                + self._completer.popup().verticalScrollBar().sizeHint().width()
+            )
+            self._completer.complete(rect)
+        else:
+            if popup:
+                popup.hide()
+
+    def canInsertFromMimeData(self, source: QMimeData) -> bool:
+        if source.hasImage() or source.hasUrls():
+            return True
+        return super().canInsertFromMimeData(source)
+
+    def insertFromMimeData(self, source: QMimeData) -> None:
+        if source.hasImage():
+            image = source.imageData()
+            if isinstance(image, QImage) and not image.isNull():
+                self._attach_image(image)
+                return
+        if source.hasUrls():
+            handled = False
+            for url in source.urls():
+                if url.isLocalFile():
+                    path = url.toLocalFile()
+                    if self._looks_like_image(path):
+                        image = QImage(path)
+                        if not image.isNull():
+                            self._attach_image(image)
+                            handled = True
+            if handled:
+                return
+        super().insertFromMimeData(source)
+
+    def _attach_image(self, image: QImage) -> None:
+        path = self._tempdir / f"paste_{_uuid.uuid4().hex}.png"
+        if not image.save(str(path), "PNG"):
+            return
+        self._pending_images.append(str(path))
+        cursor = self.textCursor()
+        cursor.insertText(f"[image:{path.name}] ")
+        self.setTextCursor(cursor)
+
+    @staticmethod
+    def _looks_like_image(path: str) -> bool:
+        return Path(path).suffix.lower() in {".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"}
+
+    def take_payload(self) -> tuple[str, List[str]]:
+        body = self.toPlainText().strip()
+        for path in self._pending_images:
+            body = body.replace(f"[image:{Path(path).name}]", "").strip()
+        images = list(self._pending_images)
+        self._pending_images.clear()
+        self.clear()
+        return body, images

--- a/SciQLop/components/agents/chat_dock.py
+++ b/SciQLop/components/agents/chat_dock.py
@@ -1,0 +1,394 @@
+"""Generic multi-backend chat dock."""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .backend import AgentBackend, BackendContext
+from .chat import ChatInput, ChatMessage, ImageBlock, TextBlock, TranscriptView
+from .registry import available_backends, create_backend
+from .tools import build_sciqlop_tools
+
+
+@dataclass
+class _AgentSession:
+    backend: AgentBackend
+    messages: List[ChatMessage] = field(default_factory=list)
+    resume_id: Optional[str] = None
+
+
+class AgentChatDock(QWidget):
+    def __init__(self, main_window, parent=None):
+        super().__init__(parent)
+        self._main_window = main_window
+        self._tools = build_sciqlop_tools(main_window)
+        self._tempdir = Path(tempfile.mkdtemp(prefix="sciqlop_agents_"))
+        self._sessions: Dict[str, _AgentSession] = {}
+        self._current: Optional[str] = None
+        self._allow_writes = False
+        self._turn_task: Optional[asyncio.Task] = None
+
+        self._build_ui()
+        self.refresh_backends()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        header = QHBoxLayout()
+        self._reset_btn = QPushButton("New session")
+        self._reset_btn.clicked.connect(self._on_reset)
+        header.addWidget(self._reset_btn)
+
+        self._interactive: tuple = ()
+
+        self._backend_combo = QComboBox()
+        self._backend_combo.setToolTip("Select which agent backend to chat with.")
+        self._backend_combo.currentIndexChanged.connect(self._on_backend_changed)
+        header.addWidget(self._backend_combo)
+
+        self._session_combo = QComboBox()
+        self._session_combo.setMinimumWidth(220)
+        self._session_combo.setToolTip("Resume a previous session for this backend.")
+        self._session_combo.currentIndexChanged.connect(self._on_session_picked)
+        header.addWidget(self._session_combo)
+
+        self._model_combo = QComboBox()
+        self._model_combo.currentIndexChanged.connect(self._on_model_changed)
+        header.addWidget(self._model_combo)
+
+        self._writes_toggle = QCheckBox("Allow write actions")
+        self._writes_toggle.setToolTip(
+            "When enabled, the agent can modify SciQLop state "
+            "(set time range, create panels, exec Python, edit notebooks)."
+        )
+        self._writes_toggle.stateChanged.connect(self._on_writes_toggled)
+        header.addWidget(self._writes_toggle)
+
+        self._status_label = QLabel("")
+        self._status_label.setStyleSheet("color: gray;")
+        header.addWidget(self._status_label, 1)
+        layout.addLayout(header)
+
+        self._transcript = TranscriptView(self)
+        layout.addWidget(self._transcript, 1)
+
+        input_row = QHBoxLayout()
+        self._input = ChatInput(self._tempdir / "pasted", self)
+        self._input.setFixedHeight(90)
+        input_row.addWidget(self._input, 1)
+
+        self._send_btn = QPushButton("Send")
+        self._send_btn.clicked.connect(self._on_send)
+        input_row.addWidget(self._send_btn)
+
+        self._stop_btn = QPushButton("Stop")
+        self._stop_btn.setVisible(False)
+        self._stop_btn.clicked.connect(self._on_stop)
+        input_row.addWidget(self._stop_btn)
+        layout.addLayout(input_row)
+
+        QShortcut(QKeySequence("Ctrl+Return"), self._input, activated=self._on_send)
+        QShortcut(QKeySequence("Ctrl+Enter"), self._input, activated=self._on_send)
+
+        self._interactive = (
+            self._input,
+            self._send_btn,
+            self._reset_btn,
+            self._writes_toggle,
+            self._session_combo,
+            self._model_combo,
+        )
+
+    def refresh_backends(self) -> None:
+        names = available_backends()
+        current = self._current
+        self._backend_combo.blockSignals(True)
+        self._backend_combo.clear()
+        for name in names:
+            self._backend_combo.addItem(name, name)
+        self._backend_combo.blockSignals(False)
+        if not names:
+            self._set_empty(
+                "No agent backends registered. Install sciqlop_claude or a "
+                "similar plugin to enable the chat."
+            )
+            return
+        self._set_enabled()
+        target = current if current in names else names[0]
+        idx = names.index(target)
+        self._backend_combo.setCurrentIndex(idx)
+        self._on_backend_changed(idx)
+
+    def _set_empty(self, reason: str) -> None:
+        self._transcript.render_messages(
+            [ChatMessage(role="error", blocks=[TextBlock(text=reason)], done=True)]
+        )
+        for w in self._interactive:
+            w.setEnabled(False)
+
+    def _set_enabled(self) -> None:
+        for w in self._interactive:
+            w.setEnabled(True)
+
+    def _set_status(self, text: str) -> None:
+        self._status_label.setText(text)
+
+    def _on_backend_changed(self, index: int) -> None:
+        name = self._backend_combo.itemData(index)
+        if not name:
+            return
+        self._current = name
+        session = self._sessions.get(name) or self._create_session(name)
+        self._sessions[name] = session
+        self._bind_to_session(session)
+
+    def _create_session(self, name: str) -> _AgentSession:
+        be_tempdir = self._tempdir / name / "tool_images"
+        be_tempdir.mkdir(parents=True, exist_ok=True)
+        ctx = BackendContext(
+            main_window=self._main_window,
+            tools=self._tools,
+            tempdir=be_tempdir,
+            confirm_cb=self._confirm_tool_call,
+            allow_writes=self._allow_writes,
+        )
+        backend = create_backend(name, ctx)
+        return _AgentSession(backend=backend)
+
+    def _bind_to_session(self, session: _AgentSession) -> None:
+        be = session.backend
+        self._transcript.set_assistant_label(be.display_name)
+        self._populate_models(be)
+        self._populate_session_list(be)
+        self._transcript.render_messages(session.messages)
+        self._transcript.flush_now()
+        asyncio.ensure_future(self._refresh_completions())
+
+    def _populate_models(self, backend: AgentBackend) -> None:
+        self._model_combo.blockSignals(True)
+        self._model_combo.clear()
+        for label, value in backend.model_choices:
+            self._model_combo.addItem(label, value)
+        self._model_combo.blockSignals(False)
+
+    def _populate_session_list(self, backend: AgentBackend) -> None:
+        self._session_combo.blockSignals(True)
+        self._session_combo.clear()
+        self._session_combo.setVisible(backend.supports_sessions)
+        if backend.supports_sessions:
+            self._session_combo.addItem("↻ Resume session…", None)
+            for entry in backend.list_sessions():
+                self._session_combo.addItem(entry.label, entry.id)
+        self._session_combo.setCurrentIndex(0)
+        self._session_combo.blockSignals(False)
+
+    def _on_model_changed(self, index: int) -> None:
+        if self._current is None:
+            return
+        value = self._model_combo.itemData(index)
+        backend = self._sessions[self._current].backend
+        asyncio.ensure_future(backend.set_model(value))
+        self._set_status(f"Model → {self._model_combo.currentText()}")
+
+    def _on_writes_toggled(self, state: int) -> None:
+        self._allow_writes = state == Qt.CheckState.Checked.value
+        for session in self._sessions.values():
+            session.backend.set_allow_writes(self._allow_writes)
+        self._set_status(
+            "Write actions enabled." if self._allow_writes else "Write actions disabled."
+        )
+
+    def _on_reset(self) -> None:
+        if self._current is None:
+            return
+        session = self._sessions[self._current]
+        session.messages = []
+        session.resume_id = None
+        self._purge_replay_tempdir(self._current)
+        self._transcript.render_messages(session.messages)
+        asyncio.ensure_future(self._reset_backend(session))
+
+    async def _reset_backend(self, session: _AgentSession) -> None:
+        await session.backend.reset()
+        self._populate_session_list(session.backend)
+
+    def _on_session_picked(self, index: int) -> None:
+        if self._current is None:
+            return
+        session_id = self._session_combo.itemData(index)
+        if not session_id:
+            return
+        session = self._sessions[self._current]
+        backend = session.backend
+        if not backend.supports_sessions or session_id == session.resume_id:
+            return
+        session.resume_id = session_id
+        self._purge_replay_tempdir(self._current)
+        replay_dir = self._tempdir / self._current / "session_replay"
+        session.messages = backend.load_session(session_id, replay_dir)
+        self._transcript.render_messages(session.messages)
+        self._transcript.flush_now()
+        self._set_status(
+            f"Resumed session {session_id[:8]} ({len(session.messages)} messages)"
+        )
+        asyncio.ensure_future(backend.resume(session_id))
+
+    def _purge_replay_tempdir(self, backend_name: str) -> None:
+        shutil.rmtree(self._tempdir / backend_name / "session_replay", ignore_errors=True)
+
+    def _on_send(self) -> None:
+        if self._current is None:
+            return
+        body, image_paths = self._input.take_payload()
+        if not body and not image_paths:
+            return
+        session = self._sessions[self._current]
+        user_blocks: list = []
+        if body:
+            user_blocks.append(TextBlock(text=body))
+        for path in image_paths:
+            user_blocks.append(ImageBlock(path=path))
+        session.messages.append(ChatMessage(role="user", blocks=user_blocks, done=True))
+        self._transcript.render_messages(session.messages)
+        self._turn_task = asyncio.ensure_future(
+            self._run_turn(session, body, image_paths)
+        )
+
+    async def _run_turn(
+        self, session: _AgentSession, prompt: str, image_paths: list
+    ) -> None:
+        self._set_running(True)
+        self._set_status("Thinking…")
+        assistant = ChatMessage(role="assistant", blocks=[], done=False)
+        session.messages.append(assistant)
+        try:
+            async for block in session.backend.ask(prompt, image_paths=image_paths):
+                self._append_block(assistant, block)
+                if self._is_current(session):
+                    self._transcript.render_messages(session.messages)
+            assistant.done = True
+            if self._is_current(session):
+                self._transcript.render_messages(session.messages)
+                self._transcript.flush_now()
+            self._set_status("Ready.")
+        except asyncio.CancelledError:
+            session.messages.append(
+                ChatMessage(
+                    role="error",
+                    blocks=[TextBlock(text="(cancelled)")],
+                    done=True,
+                )
+            )
+            self._transcript.render_messages(session.messages)
+            self._set_status("Cancelled.")
+        except Exception as e:
+            session.messages.append(
+                ChatMessage(
+                    role="error",
+                    blocks=[TextBlock(text=f"{type(e).__name__}: {e}")],
+                    done=True,
+                )
+            )
+            self._transcript.render_messages(session.messages)
+            self._set_status("Error. See history.")
+        finally:
+            self._set_running(False)
+            self._turn_task = None
+
+    def _is_current(self, session: _AgentSession) -> bool:
+        return (
+            self._current is not None
+            and self._sessions.get(self._current) is session
+        )
+
+    def _on_stop(self) -> None:
+        if self._current is None or self._turn_task is None:
+            return
+        backend = self._sessions[self._current].backend
+        asyncio.ensure_future(backend.cancel())
+
+    def _set_running(self, running: bool) -> None:
+        self._send_btn.setVisible(not running)
+        self._stop_btn.setVisible(running)
+
+    @staticmethod
+    def _append_block(message: ChatMessage, block) -> None:
+        if isinstance(block, TextBlock):
+            if message.blocks and isinstance(message.blocks[-1], TextBlock):
+                message.blocks[-1].text += block.text
+            else:
+                message.blocks.append(TextBlock(text=block.text))
+        elif isinstance(block, ImageBlock):
+            message.blocks.append(block)
+
+    async def _confirm_tool_call(self, tool_name: str, tool_input: dict) -> bool:
+        box = QMessageBox(self)
+        box.setWindowTitle(f"{self._current}: tool call")
+        box.setIcon(QMessageBox.Icon.Question)
+        box.setText(f"Allow <b>{tool_name}</b>?")
+        preview = json.dumps(tool_input, indent=2, default=str)
+        if len(preview) > 2000:
+            preview = preview[:2000] + "…"
+        box.setDetailedText(preview)
+        box.setStandardButtons(
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
+        box.setDefaultButton(QMessageBox.StandardButton.No)
+        future: asyncio.Future = asyncio.Future()
+
+        def _on_finished(_btn):
+            if not future.done():
+                future.set_result(
+                    box.standardButton(box.clickedButton())
+                    == QMessageBox.StandardButton.Yes
+                )
+            box.deleteLater()
+
+        box.finished.connect(_on_finished)
+        box.open()
+        return await future
+
+    async def _refresh_completions(self) -> None:
+        if self._current is None:
+            return
+        backend = self._sessions[self._current].backend
+        try:
+            cmds = await backend.list_slash_commands()
+        except Exception:
+            cmds = []
+        self._input.set_completions(cmds)
+
+    def closeEvent(self, event):
+        shutil.rmtree(self._tempdir, ignore_errors=True)
+        super().closeEvent(event)
+
+
+_DOCK_ATTR = "_sciqlop_agent_dock"
+
+
+def ensure_agent_dock(main_window) -> AgentChatDock:
+    dock = getattr(main_window, _DOCK_ATTR, None)
+    if dock is None:
+        dock = AgentChatDock(main_window=main_window)
+        setattr(main_window, _DOCK_ATTR, dock)
+    else:
+        dock.refresh_backends()
+    return dock

--- a/SciQLop/components/agents/chat_dock.py
+++ b/SciQLop/components/agents/chat_dock.py
@@ -45,6 +45,7 @@ class AgentChatDock(QWidget):
         self._current: Optional[str] = None
         self._allow_writes = False
         self._turn_task: Optional[asyncio.Task] = None
+        self._bg_tasks: set[asyncio.Task] = set()
 
         self._build_ui()
         self.refresh_backends()
@@ -180,7 +181,7 @@ class AgentChatDock(QWidget):
         self._populate_session_list(be)
         self._transcript.render_messages(session.messages)
         self._transcript.flush_now()
-        asyncio.ensure_future(self._refresh_completions())
+        self._spawn(self._refresh_completions())
 
     def _populate_models(self, backend: AgentBackend) -> None:
         self._model_combo.blockSignals(True)
@@ -205,7 +206,7 @@ class AgentChatDock(QWidget):
             return
         value = self._model_combo.itemData(index)
         backend = self._sessions[self._current].backend
-        asyncio.ensure_future(backend.set_model(value))
+        self._spawn(backend.set_model(value))
         self._set_status(f"Model → {self._model_combo.currentText()}")
 
     def _on_writes_toggled(self, state: int) -> None:
@@ -224,7 +225,7 @@ class AgentChatDock(QWidget):
         session.resume_id = None
         self._purge_replay_tempdir(self._current)
         self._transcript.render_messages(session.messages)
-        asyncio.ensure_future(self._reset_backend(session))
+        self._spawn(self._reset_backend(session))
 
     async def _reset_backend(self, session: _AgentSession) -> None:
         await session.backend.reset()
@@ -249,7 +250,7 @@ class AgentChatDock(QWidget):
         self._set_status(
             f"Resumed session {session_id[:8]} ({len(session.messages)} messages)"
         )
-        asyncio.ensure_future(backend.resume(session_id))
+        self._spawn(backend.resume(session_id))
 
     def _purge_replay_tempdir(self, backend_name: str) -> None:
         shutil.rmtree(self._tempdir / backend_name / "session_replay", ignore_errors=True)
@@ -299,6 +300,7 @@ class AgentChatDock(QWidget):
             )
             self._transcript.render_messages(session.messages)
             self._set_status("Cancelled.")
+            raise
         except Exception as e:
             session.messages.append(
                 ChatMessage(
@@ -323,7 +325,7 @@ class AgentChatDock(QWidget):
         if self._current is None or self._turn_task is None:
             return
         backend = self._sessions[self._current].backend
-        asyncio.ensure_future(backend.cancel())
+        self._spawn(backend.cancel())
 
     def _set_running(self, running: bool) -> None:
         self._send_btn.setVisible(not running)
@@ -375,6 +377,12 @@ class AgentChatDock(QWidget):
         except Exception:
             cmds = []
         self._input.set_completions(cmds)
+
+    def _spawn(self, coro) -> asyncio.Task:
+        task = asyncio.ensure_future(coro)
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
+        return task
 
     def closeEvent(self, event):
         shutil.rmtree(self._tempdir, ignore_errors=True)

--- a/SciQLop/components/agents/registry.py
+++ b/SciQLop/components/agents/registry.py
@@ -1,0 +1,43 @@
+"""Agent backend registry."""
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Type, Union
+
+from .backend import AgentBackend, BackendContext
+
+BackendFactory = Callable[[BackendContext], AgentBackend]
+
+_BACKENDS: Dict[str, BackendFactory] = {}
+
+
+def register_agent_backend(
+    factory_or_name: Union[BackendFactory, Type[AgentBackend], str],
+    factory: BackendFactory = None,
+) -> None:
+    """Register a backend. Preferred form: `register_agent_backend(ClaudeBackend)`
+    — the name is read from `factory.display_name`. Legacy two-arg form is
+    kept for callers that want an explicit name."""
+    if factory is None:
+        name = getattr(factory_or_name, "display_name", None)
+        if not isinstance(name, str):
+            raise TypeError(
+                "register_agent_backend(factory) requires factory.display_name"
+            )
+        _BACKENDS[name] = factory_or_name
+    else:
+        _BACKENDS[str(factory_or_name)] = factory
+
+
+def unregister_agent_backend(name: str) -> None:
+    _BACKENDS.pop(name, None)
+
+
+def available_backends() -> List[str]:
+    return sorted(_BACKENDS.keys())
+
+
+def create_backend(name: str, ctx: BackendContext) -> AgentBackend:
+    factory = _BACKENDS.get(name)
+    if factory is None:
+        raise KeyError(f"no agent backend registered: {name!r}")
+    return factory(ctx)

--- a/SciQLop/components/agents/tools/__init__.py
+++ b/SciQLop/components/agents/tools/__init__.py
@@ -1,0 +1,11 @@
+"""SciQLop tool surface exposed to LLM agents.
+
+`build_sciqlop_tools(main_window)` returns the canonical list of tools
+(read-only + write-gated) in a dict format that any agent backend can map
+to its own SDK's tool shape. Tool handlers run on the Qt main thread via
+`SciQLop.user_api.threading.on_main_thread`; callers only need to await
+the result.
+"""
+from ._builder import build_sciqlop_tools
+
+__all__ = ["build_sciqlop_tools"]

--- a/SciQLop/components/agents/tools/_builder.py
+++ b/SciQLop/components/agents/tools/_builder.py
@@ -1,0 +1,496 @@
+"""Build the canonical SciQLop tool surface for LLM agent backends.
+
+All tools are always registered so the agent session stays stable across
+write-toggle changes. Tools that mutate state carry `gated=True`; backends
+deny them entirely when writes are disabled, and otherwise prompt the user
+per call via the backend's confirm callback.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import tempfile
+from typing import Any, Callable, Dict, List, Optional
+
+from SciQLop.user_api.threading import on_main_thread
+
+from . import context
+
+
+def build_sciqlop_tools(main_window) -> List[Dict[str, Any]]:
+    tools: List[Dict[str, Any]] = [
+        _read_tool(
+            "sciqlop_active_panel",
+            "Return the currently active SciQLop plot panel: its name, time range, and the products currently plotted on it.",
+            on_main_thread(lambda: context.active_panel_snapshot(main_window)),
+        ),
+        _read_tool(
+            "sciqlop_list_panels",
+            "List all open SciQLop plot panels with their time ranges.",
+            on_main_thread(lambda: context.list_panels(main_window)),
+        ),
+        _read_tool(
+            "sciqlop_window_state",
+            "High-level snapshot of the SciQLop main window: panel count, active panel summary.",
+            on_main_thread(lambda: context.main_window_snapshot(main_window)),
+        ),
+        _screenshot_panel_tool(main_window),
+        _screenshot_plot_tool(main_window),
+        _api_reference_tool(),
+        _speasy_inventory_tool(),
+        _products_tree_tool(),
+        _wait_for_plot_data_tool(main_window),
+        _list_notebooks_tool(),
+        _read_notebook_tool(),
+    ]
+    tools.extend(_write_tools(main_window))
+    return tools
+
+
+def _read_tool(name: str, description: str, handler: Callable[[], Any]) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "description": description,
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+        "handler": lambda _input: handler(),
+    }
+
+
+def _text_tool(
+    name: str,
+    description: str,
+    schema: Dict[str, Any],
+    call: Callable[[Dict[str, Any]], Any],
+    gated: bool = False,
+) -> Dict[str, Any]:
+    async def _run(payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            result = call(payload)
+            if asyncio.iscoroutine(result):
+                result = await result
+        except Exception as e:
+            return _error_content(f"{type(e).__name__}: {e}")
+        if isinstance(result, dict) and "content" in result:
+            return result
+        return {"content": [{"type": "text", "text": str(result)}]}
+
+    return {
+        "name": name,
+        "description": description,
+        "input_schema": schema,
+        "handler": _run,
+        "gated": gated,
+    }
+
+
+def _error_content(msg: str) -> Dict[str, Any]:
+    return {"content": [{"type": "text", "text": msg}]}
+
+
+def _png_to_image_content(path: str) -> Dict[str, Any]:
+    with open(path, "rb") as f:
+        data = base64.b64encode(f.read()).decode("ascii")
+    return {"content": [{"type": "image", "data": data, "mimeType": "image/png"}]}
+
+
+def _screenshot_to_content(save_fn: Callable[[str], None]) -> Dict[str, Any]:
+    fd, path = tempfile.mkstemp(suffix=".png", prefix="sciqlop_agent_")
+    os.close(fd)
+    save_fn(path)
+    try:
+        return _png_to_image_content(path)
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _screenshot_panel_tool(main_window) -> Dict[str, Any]:
+    @on_main_thread
+    def _shoot(name: Optional[str]):
+        panel = context._panel(name) if name else context._active_panel(main_window)
+        if panel is None:
+            return _error_content(f"panel not found: {name!r}" if name else "no active panel")
+        return _screenshot_to_content(panel._get_impl_or_raise().save_png)
+
+    return {
+        "name": "sciqlop_screenshot_panel",
+        "description": "Render a PNG screenshot of a SciQLop plot panel. Pass the panel name, or omit to screenshot the active panel.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": [],
+        },
+        "handler": lambda payload: _shoot(payload.get("name")),
+    }
+
+
+def _screenshot_plot_tool(main_window) -> Dict[str, Any]:
+    @on_main_thread
+    def _shoot(name: Optional[str], plot_index: int):
+        panel = context._panel(name) if name else context._active_panel(main_window)
+        if panel is None:
+            return _error_content(f"panel not found: {name!r}" if name else "no active panel")
+        plots = panel.plots
+        if not plots:
+            return _error_content("panel has no plots")
+        if plot_index < 0 or plot_index >= len(plots):
+            return _error_content(f"plot_index {plot_index} out of range (0..{len(plots) - 1})")
+        return _screenshot_to_content(plots[plot_index]._impl.save_png)
+
+    return {
+        "name": "sciqlop_screenshot_plot",
+        "description": "Render a PNG screenshot of a single subplot inside a SciQLop panel. plot_index is 0-based. Omit name to target the active panel.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "plot_index": {"type": "integer"},
+            },
+            "required": ["plot_index"],
+        },
+        "handler": lambda payload: _shoot(payload.get("name"), int(payload["plot_index"])),
+    }
+
+
+def _api_reference_tool() -> Dict[str, Any]:
+    from . import api_reference
+    return _text_tool(
+        "sciqlop_api_reference",
+        (
+            "Introspect SciQLop's public Python API (SciQLop.user_api). "
+            "Pass an empty string to list submodules, or a submodule name like "
+            "'plot', 'gui', 'catalogs', 'virtual_products', 'threading'. Returns "
+            "markdown with class/function signatures and docstrings — call this "
+            "before writing code against user_api so you don't hallucinate method names."
+        ),
+        {
+            "type": "object",
+            "properties": {"module": {"type": "string"}},
+            "required": [],
+        },
+        lambda p: api_reference.render(str(p.get("module", ""))),
+    )
+
+
+def _speasy_inventory_tool() -> Dict[str, Any]:
+    from . import speasy_inventory
+    return _text_tool(
+        "sciqlop_speasy_inventory",
+        (
+            "Browse speasy's product inventory (speasy.inventories.data_tree). "
+            "Pass an empty string to list providers (amda, cda, ssc, archive, ...), "
+            "or a dotted path like 'amda.Parameters.MMS.MMS1' to drill into a node. "
+            "Leaves return the parameter's spz_uid, units, description and time "
+            "coverage so you can plot or fetch it. Call this before guessing "
+            "product paths."
+        ),
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": [],
+        },
+        lambda p: speasy_inventory.render(str(p.get("path", ""))),
+    )
+
+
+def _products_tree_tool() -> Dict[str, Any]:
+    from . import products_tree
+    return _text_tool(
+        "sciqlop_products_tree",
+        (
+            "Browse SciQLop's live ProductsModel — the tree that `plot_product` "
+            "actually resolves against. Pass an empty string to list top-level "
+            "providers (e.g. 'speasy'), or a `//`-joined path like "
+            "'speasy//amda//Parameters//MMS//MMS1' to drill down. Leaves return "
+            "the ready-to-use full path string to pass to `plot_product`. "
+            "PREFER this over `sciqlop_speasy_inventory` when plotting — the "
+            "speasy inventory returns spz_uid paths that `plot_product` does "
+            "NOT accept."
+        ),
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": [],
+        },
+        lambda p: products_tree.render(str(p.get("path", ""))),
+    )
+
+
+def _wait_for_plot_data_tool(main_window) -> Dict[str, Any]:
+    import time
+
+    @on_main_thread
+    def _poll_once(name: Optional[str]) -> Optional[bool]:
+        panel = context._panel(name) if name else context._active_panel(main_window)
+        if panel is None:
+            return None
+        any_plot = False
+        for plot in panel.plots or []:
+            impl = getattr(plot, "_impl", None)
+            if impl is None:
+                continue
+            for graph in impl.plottables() or []:
+                any_plot = True
+                if bool(graph.property("busy")):
+                    return False
+        return any_plot
+
+    async def _wait(name: Optional[str], timeout: float) -> Dict[str, Any]:
+        deadline = time.monotonic() + max(0.1, float(timeout))
+        while time.monotonic() < deadline:
+            state = _poll_once(name)
+            if state is None:
+                return _error_content(f"panel not found: {name!r}" if name else "no active panel")
+            if state:
+                return {"content": [{"type": "text", "text": "ok: all plottables settled"}]}
+            await asyncio.sleep(0.2)
+        return {"content": [{"type": "text", "text": f"timeout after {timeout:.1f}s — plottables still busy"}]}
+
+    return _text_tool(
+        "sciqlop_wait_for_plot_data",
+        (
+            "Block until all plottables on a panel have finished fetching data "
+            "(polls the `busy` flag of every graph). Call this right after "
+            "`plot_product` and before `sciqlop_screenshot_panel`, otherwise "
+            "the screenshot captures an empty plot. Default timeout 10 seconds."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "timeout": {"type": "number"},
+            },
+            "required": [],
+        },
+        lambda p: _wait(p.get("name"), p.get("timeout", 10.0)),
+    )
+
+
+def _list_notebooks_tool() -> Dict[str, Any]:
+    from . import notebooks
+    return _text_tool(
+        "sciqlop_list_notebooks",
+        (
+            "List all Jupyter notebooks (*.ipynb) inside the active SciQLop "
+            "workspace directory, with cell counts and sizes."
+        ),
+        {"type": "object", "properties": {}, "required": []},
+        lambda _: notebooks.list_notebooks(),
+    )
+
+
+def _read_notebook_tool() -> Dict[str, Any]:
+    from . import notebooks
+    return _text_tool(
+        "sciqlop_read_notebook",
+        (
+            "Read a workspace notebook and return its cells as markdown "
+            "(code cells in ```python fences, markdown cells verbatim). "
+            "Path is relative to the workspace dir."
+        ),
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        lambda p: notebooks.read_notebook(str(p["path"])),
+    )
+
+
+def _write_tools(main_window) -> List[Dict[str, Any]]:
+    @on_main_thread
+    def _set_time_range(name: Optional[str], start: float, stop: float):
+        panel = context._panel(name) if name else context._active_panel(main_window)
+        if panel is None:
+            return _error_content(f"panel not found: {name!r}" if name else "no active panel")
+        from SciQLop.core import TimeRange
+        panel.time_range = TimeRange(float(start), float(stop))
+        label = name or "active panel"
+        return {"content": [{"type": "text", "text": f"ok: set {label} time range"}]}
+
+    set_time_range = _text_tool(
+        "sciqlop_set_time_range",
+        (
+            "Set a plot panel's time range. Arguments are POSIX timestamps in "
+            "seconds. Pass `name` to target a specific panel, or omit to target "
+            "the active panel."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "start": {"type": "number"},
+                "stop": {"type": "number"},
+            },
+            "required": ["start", "stop"],
+        },
+        lambda p: _set_time_range(p.get("name"), p["start"], p["stop"]),
+        gated=True,
+    )
+
+    return [set_time_range, _create_panel_tool(main_window), _exec_python_tool()] + _notebook_write_tools()
+
+
+def _create_panel_tool(main_window) -> Dict[str, Any]:
+    @on_main_thread
+    def _create() -> Dict[str, Any]:
+        from SciQLop.user_api.plot import create_plot_panel
+        before = set(context._panel_names())
+        panel = create_plot_panel()
+        after = context._panel_names()
+        new_name = next((n for n in after if n not in before), after[-1] if after else "")
+        tr = context._time_range_dict(panel) if panel is not None else None
+        body = f"created panel `{new_name}`"
+        if tr:
+            body += f"\ntime_range: [{tr['start']}, {tr['stop']}]"
+        return {"content": [{"type": "text", "text": body}]}
+
+    return _text_tool(
+        "sciqlop_create_panel",
+        (
+            "Create a new empty plot panel and return its name. Use the returned "
+            "name with `sciqlop_exec_python` (e.g. "
+            "`plot_panel('Panel3').plot_product(...)`), `sciqlop_set_time_range`, "
+            "`sciqlop_screenshot_panel` and `sciqlop_wait_for_plot_data` to target "
+            "that specific panel instead of relying on which one is active."
+        ),
+        {"type": "object", "properties": {}, "required": []},
+        lambda _: _create(),
+        gated=True,
+    )
+
+
+def _exec_python_tool() -> Dict[str, Any]:
+    @on_main_thread
+    def _run(code: str) -> Dict[str, Any]:
+        shell = _get_shell()
+        if shell is None:
+            return _error_content("embedded IPython shell is not available")
+        from IPython.utils.capture import capture_output
+        with capture_output() as cap:
+            result = shell.run_cell(code, store_history=False)
+        lines: List[str] = []
+        if cap.stdout:
+            lines.append(f"stdout:\n{cap.stdout.rstrip()}")
+        if cap.stderr:
+            lines.append(f"stderr:\n{cap.stderr.rstrip()}")
+        if result.result is not None:
+            lines.append(f"result: {result.result!r}")
+        if not result.success:
+            err = result.error_in_exec or result.error_before_exec
+            if err is not None:
+                lines.append(f"error: {type(err).__name__}: {err}")
+            else:
+                lines.append("error: cell failed without exception detail")
+        if not lines:
+            lines.append("ok (no output)")
+        return {"content": [{"type": "text", "text": "\n\n".join(lines)}]}
+
+    return _text_tool(
+        "sciqlop_exec_python",
+        (
+            "Run arbitrary Python in the SciQLop embedded IPython kernel. "
+            "The SciQLop `user_api` (sciqlop.user_api.plot, user_api.gui, user_api.catalogs, "
+            "user_api.virtual_products), speasy, numpy and the main window are all "
+            "importable. Prefer this over bespoke tools for anything SciQLop-related. "
+            "Returns captured stdout/stderr, repr of the last expression, and any exception."
+        ),
+        {
+            "type": "object",
+            "properties": {"code": {"type": "string"}},
+            "required": ["code"],
+        },
+        lambda p: _run(str(p["code"])),
+        gated=True,
+    )
+
+
+_CELL_TYPES = ["code", "markdown", "raw"]
+
+
+def _notebook_write_tools() -> List[Dict[str, Any]]:
+    from . import notebooks
+
+    def _write(p):
+        return notebooks.write_cell(
+            str(p["path"]), int(p["index"]), str(p["source"]), p.get("cell_type")
+        )
+
+    def _insert(p):
+        return notebooks.insert_cell(
+            str(p["path"]), int(p["index"]), str(p["source"]),
+            str(p.get("cell_type", "code")),
+        )
+
+    def _delete(p):
+        return notebooks.delete_cell(str(p["path"]), int(p["index"]))
+
+    def _create(p):
+        return notebooks.create_notebook(str(p["path"]))
+
+    cell_schema = {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "index": {"type": "integer"},
+            "source": {"type": "string"},
+            "cell_type": {"type": "string", "enum": _CELL_TYPES},
+        },
+        "required": ["path", "index", "source"],
+    }
+
+    return [
+        _text_tool(
+            "sciqlop_write_notebook_cell",
+            (
+                "Replace the source of a single cell in a workspace notebook. "
+                "Clears execution outputs for code cells. Optionally change "
+                "the cell_type ('code', 'markdown', 'raw')."
+            ),
+            cell_schema, _write, gated=True,
+        ),
+        _text_tool(
+            "sciqlop_insert_notebook_cell",
+            "Insert a new cell at the given index in a workspace notebook. cell_type defaults to 'code'.",
+            cell_schema, _insert, gated=True,
+        ),
+        _text_tool(
+            "sciqlop_delete_notebook_cell",
+            "Delete the cell at the given index in a workspace notebook.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "index": {"type": "integer"},
+                },
+                "required": ["path", "index"],
+            },
+            _delete, gated=True,
+        ),
+        _text_tool(
+            "sciqlop_create_notebook",
+            (
+                "Create a new empty Jupyter notebook at the given workspace-relative "
+                "path. Fails if the file already exists."
+            ),
+            {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            _create, gated=True,
+        ),
+    ]
+
+
+def _get_shell():
+    try:
+        from SciQLop.components.workspaces import workspaces_manager_instance
+        mgr = workspaces_manager_instance()
+        km = getattr(mgr, "_kernel_manager", None)
+        return getattr(km, "shell", None) if km is not None else None
+    except Exception:
+        return None

--- a/SciQLop/components/agents/tools/_text.py
+++ b/SciQLop/components/agents/tools/_text.py
@@ -1,0 +1,17 @@
+"""Tiny shared text helpers for the markdown renderers."""
+from __future__ import annotations
+
+
+def first_line(text: str) -> str:
+    for line in str(text).splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def trim_lines(text: str, max_lines: int) -> str:
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    return "\n".join(lines[:max_lines] + ["…"])

--- a/SciQLop/components/agents/tools/api_reference.py
+++ b/SciQLop/components/agents/tools/api_reference.py
@@ -1,0 +1,222 @@
+"""Markdown introspection of `SciQLop.user_api` for LLM agents."""
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any, List
+
+from ._text import first_line, trim_lines
+
+_ROOT = "SciQLop.user_api"
+_MAX_DOC_LINES = 8
+
+
+def render(module: str) -> str:
+    module = (module or "").strip().strip(".")
+    if not module:
+        return _render_index()
+    full = f"{_ROOT}.{module}"
+    mod = importlib.import_module(full)
+    return _render_module(mod, module)
+
+
+def _render_index() -> str:
+    root = importlib.import_module(_ROOT)
+    lines: List[str] = [
+        f"# `{_ROOT}` — public API index",
+        "",
+        "Call `sciqlop_api_reference('<submodule>')` to expand any of these.",
+        "",
+    ]
+    for name, is_pkg in _iter_submodules(root):
+        summary = _one_line_doc(importlib.import_module(f"{_ROOT}.{name}"))
+        marker = "📦" if is_pkg else "📄"
+        lines.append(f"- {marker} **`{name}`** — {summary}")
+    root_doc = _one_line_doc(root)
+    if root_doc:
+        lines.insert(2, f"> {root_doc}")
+        lines.insert(3, "")
+    return "\n".join(lines)
+
+
+def _iter_submodules(package) -> List[tuple[str, bool]]:
+    if not hasattr(package, "__path__"):
+        return []
+    out: List[tuple[str, bool]] = []
+    for info in pkgutil.iter_modules(package.__path__):
+        if info.name.startswith("_"):
+            continue
+        out.append((info.name, info.ispkg))
+    out.sort()
+    return out
+
+
+def _render_module(mod, short_name: str) -> str:
+    lines: List[str] = [f"# `{_ROOT}.{short_name}`"]
+    doc = inspect.getdoc(mod)
+    if doc:
+        lines += ["", doc.strip()]
+
+    public = _public_members(mod)
+    modules = [(n, o) for n, o in public if inspect.ismodule(o)]
+    classes = [(n, o) for n, o in public if inspect.isclass(o)]
+    functions = [
+        (n, o) for n, o in public
+        if inspect.isroutine(o) and not inspect.isclass(o)
+    ]
+    others = [
+        (n, o) for n, o in public
+        if not (inspect.ismodule(o) or inspect.isclass(o) or inspect.isroutine(o))
+    ]
+
+    if functions:
+        lines += ["", "## Functions", ""]
+        for name, fn in functions:
+            lines += _render_callable(name, fn, heading_level=3)
+
+    if classes:
+        lines += ["", "## Classes", ""]
+        for name, cls in classes:
+            lines += _render_class(name, cls)
+
+    if modules:
+        lines += ["", "## Re-exported modules", ""]
+        for name, submod in modules:
+            origin = getattr(submod, "__name__", "?")
+            summary = _one_line_doc(submod)
+            suffix = f" — {summary}" if summary else ""
+            lines.append(f"- **`{name}`** (`{origin}`){suffix}")
+
+    if others:
+        lines += ["", "## Constants / values", ""]
+        for name, obj in others:
+            lines.append(f"- `{name}` — `{type(obj).__name__}`")
+
+    submods = _iter_submodules(mod)
+    if submods:
+        lines += ["", "## Submodules", ""]
+        for name, is_pkg in submods:
+            marker = "📦" if is_pkg else "📄"
+            lines.append(
+                f"- {marker} **`{short_name}.{name}`** — "
+                f"call `sciqlop_api_reference('{short_name}.{name}')`"
+            )
+
+    return "\n".join(lines)
+
+
+def _public_members(mod) -> List[tuple[str, Any]]:
+    exported = getattr(mod, "__all__", None)
+    out: List[tuple[str, Any]] = []
+    if exported is not None:
+        for name in exported:
+            if name.startswith("_"):
+                continue
+            obj = getattr(mod, name, None)
+            if obj is None:
+                continue
+            out.append((name, obj))
+    else:
+        for name, obj in inspect.getmembers(mod):
+            if name.startswith("_"):
+                continue
+            if not _belongs_to(obj, mod):
+                continue
+            out.append((name, obj))
+    out.sort(key=lambda it: it[0])
+    return out
+
+
+def _belongs_to(obj, mod) -> bool:
+    origin = getattr(obj, "__module__", None)
+    if origin is None:
+        return False
+    return origin == mod.__name__ or origin.startswith(mod.__name__ + ".")
+
+
+def _render_callable(name: str, fn, heading_level: int) -> List[str]:
+    sig = _safe_signature(fn)
+    header = "#" * heading_level
+    lines = [f"{header} `{name}{sig}`"]
+    doc = inspect.getdoc(fn)
+    if doc:
+        lines.append("")
+        lines.append(_trim_doc(doc))
+    lines.append("")
+    return lines
+
+
+def _render_class(name: str, cls) -> List[str]:
+    sig = _safe_signature(cls)
+    lines = [f"### `class {name}{sig}`"]
+    doc = inspect.getdoc(cls)
+    if doc:
+        lines += ["", _trim_doc(doc)]
+    methods = _public_class_members(cls)
+    if methods:
+        lines += ["", "**Members:**", ""]
+        for m_name, m_obj, kind in methods:
+            lines.append(_render_class_member(m_name, m_obj, kind))
+    lines.append("")
+    return lines
+
+
+def _render_class_member(name: str, obj, kind: str) -> str:
+    if kind == "property":
+        fget = getattr(obj, "fget", None)
+        doc = inspect.getdoc(fget) if fget else inspect.getdoc(obj)
+        one_line = first_line(doc) if doc else ""
+        suffix = f" — {one_line}" if one_line else ""
+        return f"- `{name}` *(property)*{suffix}"
+    if kind == "attribute":
+        return f"- `{name}` — `{type(obj).__name__}`"
+    sig = _safe_signature(obj)
+    doc = inspect.getdoc(obj)
+    one_line = first_line(doc) if doc else ""
+    suffix = f" — {one_line}" if one_line else ""
+    tag = ""
+    if kind == "staticmethod":
+        tag = " *(static)*"
+    elif kind == "classmethod":
+        tag = " *(classmethod)*"
+    return f"- `{name}{sig}`{tag}{suffix}"
+
+
+def _public_class_members(cls) -> List[tuple[str, Any, str]]:
+    out: List[tuple[str, Any, str]] = []
+    for name in dir(cls):
+        if name.startswith("_"):
+            continue
+        raw = inspect.getattr_static(cls, name, None)
+        if raw is None:
+            continue
+        if isinstance(raw, property):
+            out.append((name, raw, "property"))
+        elif isinstance(raw, staticmethod):
+            out.append((name, raw.__func__, "staticmethod"))
+        elif isinstance(raw, classmethod):
+            out.append((name, raw.__func__, "classmethod"))
+        elif inspect.isfunction(raw) or inspect.ismethoddescriptor(raw) or inspect.isbuiltin(raw):
+            out.append((name, raw, "method"))
+        elif callable(raw):
+            out.append((name, raw, "method"))
+        else:
+            out.append((name, raw, "attribute"))
+    out.sort(key=lambda it: it[0])
+    return out
+
+
+def _safe_signature(obj) -> str:
+    try:
+        return str(inspect.signature(obj))
+    except (TypeError, ValueError):
+        return ""
+
+
+def _one_line_doc(obj) -> str:
+    return first_line(inspect.getdoc(obj) or "")
+
+
+def _trim_doc(doc: str) -> str:
+    return trim_lines(doc, _MAX_DOC_LINES)

--- a/SciQLop/components/agents/tools/context.py
+++ b/SciQLop/components/agents/tools/context.py
@@ -1,0 +1,113 @@
+"""Snapshot SciQLop state into JSON-serializable dicts for agent tool calls.
+
+Uses the public user API (`SciQLop.user_api.gui.get_main_window`,
+`SciQLop.user_api.plot.plot_panel`) instead of walking dock widgets, so we
+don't depend on private class names or dock-manager wrapping details.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from SciQLop.user_api.gui import get_main_window
+from SciQLop.user_api.plot import plot_panel as _plot_panel_by_name, PlotPanel
+
+
+def _safe(call, default=None):
+    try:
+        return call()
+    except Exception:
+        return default
+
+
+def _panel_names() -> List[str]:
+    mw = _safe(get_main_window)
+    if mw is None:
+        return []
+    return list(_safe(mw.plot_panels, []) or [])
+
+
+def _panel(name: str) -> Optional[PlotPanel]:
+    return _safe(lambda: _plot_panel_by_name(name))
+
+
+def _time_range_dict(panel: PlotPanel) -> Dict[str, float] | None:
+    tr = _safe(lambda: panel.time_range)
+    if tr is None:
+        return None
+    start = _safe(tr.start)
+    stop = _safe(tr.stop)
+    if start is None or stop is None:
+        return None
+    return {"start": float(start), "stop": float(stop)}
+
+
+def _panel_products(panel: PlotPanel) -> List[str]:
+    products: List[str] = []
+    for plot in _safe(lambda: panel.plots, []) or []:
+        impl = getattr(plot, "_impl", None)
+        if impl is None:
+            continue
+        for graph in _safe(lambda: impl.plottables(), []) or []:
+            path = _safe(lambda g=graph: g.property("sqp_product_path"))
+            if path:
+                products.append(path)
+    return products
+
+
+def _panel_snapshot(panel: PlotPanel, name: str) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "time_range": _time_range_dict(panel),
+        "products": _panel_products(panel),
+    }
+
+
+def _active_panel_name(main_window) -> Optional[str]:
+    dock_manager = getattr(main_window, "dock_manager", None)
+    if dock_manager is None:
+        return None
+    focused = _safe(dock_manager.focusedDockWidget)
+    if focused is not None:
+        name = _safe(focused.windowTitle, "") or ""
+        if name in _panel_names():
+            return name
+    names = _panel_names()
+    return names[0] if names else None
+
+
+def main_window_snapshot(_main_window) -> Dict[str, Any]:
+    mw = _safe(get_main_window)
+    names = _panel_names()
+    return {
+        "window_title": _safe(lambda: mw.windowTitle(), "") if mw else "",
+        "panel_count": len(names),
+        "panel_names": names,
+        "active_panel": active_panel_snapshot(_main_window),
+    }
+
+
+def list_panels(_main_window) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for name in _panel_names():
+        p = _panel(name)
+        if p is None:
+            continue
+        out.append({"name": name, "time_range": _time_range_dict(p)})
+    return out
+
+
+def active_panel_snapshot(main_window) -> Dict[str, Any] | None:
+    name = _active_panel_name(main_window)
+    if name is None:
+        return None
+    p = _panel(name)
+    if p is None:
+        return None
+    return _panel_snapshot(p, name)
+
+
+def _active_panel(main_window) -> Optional[PlotPanel]:
+    name = _active_panel_name(main_window)
+    if name is None:
+        return None
+    return _panel(name)

--- a/SciQLop/components/agents/tools/notebooks.py
+++ b/SciQLop/components/agents/tools/notebooks.py
@@ -1,0 +1,167 @@
+"""Workspace notebook inspection / editing helpers.
+
+Paths are resolved relative to the active SciQLop workspace directory
+and confined to it — no traversal outside.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_PRUNED_DIRS = {
+    ".venv", "venv", ".ipynb_checkpoints", "__pycache__", ".git",
+    "node_modules", "site-packages", "archive", ".tox", ".mypy_cache",
+}
+
+
+def workspace_dir() -> Path:
+    env = os.environ.get("SCIQLOP_WORKSPACE_DIR")
+    if env:
+        return Path(env).resolve()
+    try:
+        from SciQLop.components.workspaces import workspaces_manager_instance
+        ws = workspaces_manager_instance().workspace
+        return Path(ws.workspace_dir).resolve()
+    except Exception as e:
+        raise RuntimeError(f"cannot determine workspace dir: {e}")
+
+
+def _resolve_notebook(rel_path: str) -> Path:
+    base = workspace_dir()
+    candidate = (base / rel_path).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError:
+        raise ValueError(f"path escapes workspace: {rel_path!r}")
+    if candidate.suffix != ".ipynb":
+        raise ValueError(f"not a notebook path: {rel_path!r}")
+    return candidate
+
+
+def _walk_notebooks(base: Path) -> List[Path]:
+    out: List[Path] = []
+    for root, dirs, files in os.walk(base):
+        dirs[:] = [d for d in dirs if d not in _PRUNED_DIRS and not d.startswith(".")]
+        for name in files:
+            if name.endswith(".ipynb"):
+                out.append(Path(root) / name)
+    out.sort()
+    return out
+
+
+def list_notebooks() -> str:
+    base = workspace_dir()
+    notebooks = _walk_notebooks(base)
+    if not notebooks:
+        return f"# Notebooks in `{base}`\n\n*(none found)*"
+    lines = [f"# Notebooks in `{base}`", ""]
+    for nb in notebooks:
+        rel = nb.relative_to(base)
+        size_kb = nb.stat().st_size / 1024
+        lines.append(f"- `{rel}` — {_count_cells(nb)} cells, {size_kb:.1f} KiB")
+    return "\n".join(lines)
+
+
+def _count_cells(path: Path) -> int:
+    try:
+        with path.open("rb") as f:
+            return len(json.load(f).get("cells", []))
+    except Exception:
+        return -1
+
+
+def read_notebook(rel_path: str) -> str:
+    import nbformat
+    nb_path = _resolve_notebook(rel_path)
+    nb = nbformat.read(str(nb_path), as_version=4)
+    lines = [f"# `{rel_path}` — {len(nb.cells)} cells", ""]
+    for i, cell in enumerate(nb.cells):
+        lines += _render_cell(i, cell)
+    return "\n".join(lines)
+
+
+def _render_cell(index: int, cell) -> List[str]:
+    kind = cell.get("cell_type", "?")
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        src = "".join(src)
+    header = f"## Cell {index} — `{kind}`"
+    if kind == "code":
+        body = f"```python\n{src}\n```"
+    elif kind == "markdown":
+        body = f"````markdown\n{src}\n````"
+    else:
+        body = f"```\n{src}\n```"
+    return [header, "", body, ""]
+
+
+def write_cell(rel_path: str, index: int, source: str, cell_type: Optional[str]) -> Dict[str, Any]:
+    import nbformat
+    nb_path = _resolve_notebook(rel_path)
+    nb = nbformat.read(str(nb_path), as_version=4)
+    if index < 0 or index >= len(nb.cells):
+        return {"ok": False, "error": f"index {index} out of range (0..{len(nb.cells) - 1})"}
+    cell = nb.cells[index]
+    if cell_type and cell_type != cell.get("cell_type"):
+        nb.cells[index] = _new_cell(cell_type, source)
+    else:
+        cell["source"] = source
+        if cell.get("cell_type") == "code":
+            cell["outputs"] = []
+            cell["execution_count"] = None
+    nbformat.write(nb, str(nb_path))
+    return {"ok": True, "path": str(nb_path)}
+
+
+def insert_cell(rel_path: str, index: int, source: str, cell_type: str) -> Dict[str, Any]:
+    import nbformat
+    nb_path = _resolve_notebook(rel_path)
+    nb = nbformat.read(str(nb_path), as_version=4)
+    index = max(0, min(index, len(nb.cells)))
+    nb.cells.insert(index, _new_cell(cell_type, source))
+    nbformat.write(nb, str(nb_path))
+    return {"ok": True, "path": str(nb_path), "index": index}
+
+
+def delete_cell(rel_path: str, index: int) -> Dict[str, Any]:
+    import nbformat
+    nb_path = _resolve_notebook(rel_path)
+    nb = nbformat.read(str(nb_path), as_version=4)
+    if index < 0 or index >= len(nb.cells):
+        return {"ok": False, "error": f"index {index} out of range (0..{len(nb.cells) - 1})"}
+    del nb.cells[index]
+    nbformat.write(nb, str(nb_path))
+    return {"ok": True, "path": str(nb_path)}
+
+
+def create_notebook(rel_path: str) -> Dict[str, Any]:
+    import nbformat
+    base = workspace_dir()
+    target = (base / rel_path).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError:
+        return {"ok": False, "error": f"path escapes workspace: {rel_path!r}"}
+    if target.suffix != ".ipynb":
+        return {"ok": False, "error": "path must end in .ipynb"}
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError:
+        return {"ok": False, "error": f"already exists: {rel_path}"}
+    with os.fdopen(fd, "w") as f:
+        nbformat.write(nbformat.v4.new_notebook(), f)
+    return {"ok": True, "path": str(target)}
+
+
+def _new_cell(cell_type: str, source: str):
+    import nbformat
+    if cell_type == "code":
+        return nbformat.v4.new_code_cell(source)
+    if cell_type == "markdown":
+        return nbformat.v4.new_markdown_cell(source)
+    if cell_type == "raw":
+        return nbformat.v4.new_raw_cell(source)
+    raise ValueError(f"unknown cell_type: {cell_type!r}")

--- a/SciQLop/components/agents/tools/products_tree.py
+++ b/SciQLop/components/agents/tools/products_tree.py
@@ -1,0 +1,156 @@
+"""Markdown browser for SciQLop's live ProductsModel.
+
+Unlike `speasy_inventory` (which returns spz_uid-flavored paths for
+`speasy.get_data`), this walks the tree that `PlotPanel.plot_product`
+actually resolves against — display names with spaces, rooted at
+"speasy". Leaves return a ready-to-use `//`-joined path.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from ._text import first_line  # noqa: F401 — reserved for future summaries
+
+
+def render(path: str) -> str:
+    from SciQLopPlots import ProductsModel, ProductsModelNodeType
+
+    parts = _split_path(path)
+    pm = ProductsModel.instance()
+    node = pm.node(parts)
+    if node is None:
+        return f"no products node at path `{path}`" if path else _render_root(pm, ProductsModelNodeType)
+
+    if _is_parameter(node, ProductsModelNodeType):
+        return _render_parameter(parts, node)
+    return _render_folder(parts, node, ProductsModelNodeType)
+
+
+def _split_path(path: str) -> List[str]:
+    path = (path or "").strip().strip("/")
+    if not path:
+        return []
+    if "//" in path:
+        return [p for p in path.split("//") if p]
+    return [p for p in path.split("/") if p]
+
+
+def _render_root(pm, node_types) -> str:
+    root = pm.node([])
+    if root is None:
+        return "# Products tree is empty — no providers loaded."
+    return _render_folder([], root, node_types)
+
+
+def _render_folder(parts: List[str], node, node_types) -> str:
+    folders: List[Tuple[str, object]] = []
+    parameters: List[Tuple[str, object]] = []
+    for child in _children(node):
+        name = child.name()
+        if _is_parameter(child, node_types):
+            parameters.append((name, child))
+        else:
+            folders.append((name, child))
+
+    title = "//".join(parts) if parts else "<root>"
+    lines = [f"# `{title}`", ""]
+    if parts:
+        lines.append(
+            "Path format for `plot_product`: the items listed below joined "
+            "with `//`, e.g. `" + "//".join(parts + ["<child>"]) + "`."
+        )
+        lines.append("")
+
+    if folders:
+        lines += [f"## Folders ({len(folders)})", ""]
+        for name, _ in folders:
+            lines.append(f"- 📁 **`{name}`**")
+        lines.append("")
+
+    if parameters:
+        lines += [f"## Parameters ({len(parameters)})", ""]
+        for name, p in parameters:
+            full = "//".join(parts + [name])
+            meta = _parameter_meta(p)
+            suffix = f" — {meta}" if meta else ""
+            lines.append(f"- 📊 `{full}`{suffix}")
+        lines.append("")
+
+    if not folders and not parameters:
+        lines.append("*(empty node)*")
+    else:
+        sample = (folders + parameters)[0][0]
+        next_path = "//".join(parts + [sample]) if parts else sample
+        lines.append(
+            f"Drill deeper with `sciqlop_products_tree('{next_path}')`."
+        )
+
+    return "\n".join(lines)
+
+
+def _render_parameter(parts: List[str], node) -> str:
+    full = "//".join(parts)
+    lines = [
+        f"# `{full}` — parameter",
+        "",
+        f"**Full path (ready for `plot_product`):** `{full}`",
+        "",
+    ]
+    ptype = _safe(lambda: str(node.parameter_type()).rsplit(".", 1)[-1])
+    if ptype:
+        lines.append(f"- **parameter_type**: `{ptype}`")
+    provider = _safe(lambda: node.provider())
+    if provider:
+        lines.append(f"- **provider**: `{provider}`")
+    tooltip = _safe(lambda: node.tooltip())
+    if tooltip:
+        lines += ["", "**Tooltip:**", "", str(tooltip)]
+    lines += [
+        "",
+        "**Usage:**",
+        "",
+        "```python",
+        "from SciQLop.user_api.plot import create_plot_panel",
+        "panel = create_plot_panel()",
+        f'panel.plot_product("{full}")',
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def _children(node) -> List[object]:
+    try:
+        n = node.children_count()
+    except Exception:
+        return []
+    out = []
+    for i in range(n):
+        c = _safe(lambda i=i: node.child(i))
+        if c is not None:
+            out.append(c)
+    return out
+
+
+def _is_parameter(node, node_types) -> bool:
+    try:
+        return node.node_type() == node_types.PARAMETER
+    except Exception:
+        return False
+
+
+def _parameter_meta(node) -> str:
+    bits = []
+    ptype = _safe(lambda: str(node.parameter_type()).rsplit(".", 1)[-1])
+    if ptype:
+        bits.append(ptype)
+    provider = _safe(lambda: node.provider())
+    if provider:
+        bits.append(f"via `{provider}`")
+    return " ".join(bits)
+
+
+def _safe(fn):
+    try:
+        return fn()
+    except Exception:
+        return None

--- a/SciQLop/components/agents/tools/speasy_inventory.py
+++ b/SciQLop/components/agents/tools/speasy_inventory.py
@@ -1,0 +1,154 @@
+"""Markdown browser for `speasy.inventories.data_tree` (provider → parameter)."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from ._text import first_line, trim_lines
+
+
+def render(path: str) -> str:
+    import speasy as spz
+    from speasy.core.inventory.indexes import ParameterIndex, SpeasyIndex
+
+    path = (path or "").strip().strip(".")
+    root = spz.inventories.data_tree
+
+    if not path:
+        return _render_providers(root)
+
+    node = _resolve(root, path)
+    if node is None:
+        return f"no inventory node at path `{path}`"
+
+    if isinstance(node, ParameterIndex):
+        return _render_parameter(path, node)
+
+    if isinstance(node, SpeasyIndex):
+        return _render_dir(path, node, ParameterIndex)
+
+    return f"unexpected node type at `{path}`: {type(node).__name__}"
+
+
+def _resolve(root, path: str):
+    node = root
+    for part in path.split("."):
+        node = getattr(node, part, None)
+        if node is None:
+            return None
+    return node
+
+
+def _render_providers(root) -> str:
+    providers = sorted(k for k in dir(root) if not k.startswith("_"))
+    lines = [
+        "# `speasy.inventories.data_tree` — providers",
+        "",
+        "Call `sciqlop_speasy_inventory('<provider>')` to drill in.",
+        "",
+    ]
+    for p in providers:
+        lines.append(f"- **`{p}`**")
+    return "\n".join(lines)
+
+
+def _render_dir(path: str, node, ParameterIndex) -> str:
+    dirs: List[Tuple[str, object]] = []
+    params: List[Tuple[str, object]] = []
+    for name in sorted(dir(node)):
+        if name.startswith("_"):
+            continue
+        child = getattr(node, name, None)
+        if child is None or getattr(child, "spz_name", None) is None:
+            continue
+        if isinstance(child, ParameterIndex):
+            params.append((name, child))
+        else:
+            dirs.append((name, child))
+
+    lines = [f"# `{path}`", ""]
+    doc = first_line(getattr(node, "description", "") or "")
+    if doc:
+        lines += [f"> {doc}", ""]
+
+    if dirs:
+        lines += [f"## Subdirectories ({len(dirs)})", ""]
+        for name, child in dirs:
+            label = type(child).__name__
+            display = _display_name(child, name)
+            lines.append(
+                f"- **`{name}`** — {label}"
+                + (f" — {display}" if display and display != name else "")
+            )
+        lines.append("")
+
+    if params:
+        lines += [f"## Parameters ({len(params)})", ""]
+        for name, p in params:
+            lines.append(f"- `{name}` — {_param_summary(p)}")
+        lines.append("")
+
+    if not dirs and not params:
+        lines.append("*(empty node)*")
+
+    lines.append(
+        f"\nDrill deeper with `sciqlop_speasy_inventory('{path}.<child>')`."
+    )
+    return "\n".join(lines)
+
+
+def _render_parameter(path: str, p) -> str:
+    lines = [f"# `{path}` — parameter", ""]
+    lines.append(f"- **name**: {_display_name(p, path.rsplit('.', 1)[-1])}")
+    uid = _call(p, "spz_uid")
+    provider = _call(p, "spz_provider")
+    if uid:
+        lines.append(f"- **spz_uid**: `{uid}`")
+    if provider:
+        lines.append(f"- **provider**: `{provider}`")
+    for attr in ("units", "start_date", "stop_date", "dataset"):
+        val = getattr(p, attr, None)
+        if val:
+            lines.append(f"- **{attr}**: {val}")
+    desc = getattr(p, "description", None)
+    if desc:
+        lines += ["", "**Description:**", "", trim_lines(str(desc), 12)]
+    if uid and provider:
+        lines += [
+            "",
+            "**Fetch example:**",
+            "",
+            "```python",
+            "import speasy as spz",
+            f"v = spz.get_data('{provider}/{uid}', start, stop)",
+            "```",
+        ]
+    return "\n".join(lines)
+
+
+def _param_summary(p) -> str:
+    bits = []
+    display = _display_name(p, "")
+    if display:
+        bits.append(display)
+    units = getattr(p, "units", None)
+    if units:
+        bits.append(f"[{units}]")
+    uid = _call(p, "spz_uid")
+    if uid:
+        bits.append(f"uid=`{uid}`")
+    return " ".join(bits) if bits else "parameter"
+
+
+def _display_name(node, fallback: str) -> str:
+    name = _call(node, "spz_name") or getattr(node, "name", None) or fallback
+    return str(name) if name else fallback
+
+
+def _call(node, attr: str):
+    fn = getattr(node, attr, None)
+    if fn is None:
+        return None
+    try:
+        return fn() if callable(fn) else fn
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary

Adds `SciQLop/components/agents/`, a plugin-agnostic LLM chat framework for SciQLop:

- **`AgentBackend` Protocol** + `BackendContext` / `SessionEntry` dataclasses — the contract any LLM adapter implements (`ask`, `reset`, `cancel`, `resume`, `set_model`, `list_sessions`, `load_session`, …).
- **Registry** — `register_agent_backend(BackendFactory)` keyed off the class's `display_name`.
- **`AgentChatDock`** — generic Qt dock that holds one `_AgentSession` per registered backend, flips between them via a dropdown, and streams assistant blocks into a shared transcript. Backends are lazy-instantiated. The dock is stored on `main_window` so it's a natural singleton without module-level globals.
- **Tool surface** — `build_sciqlop_tools(main_window)` exposes the read/write tools plugins share: window/panel snapshots, screenshots, products tree walk, api reference dump, speasy inventory browse, notebook read/write, `exec_python`, `wait_for_plot_data`.
- **Chat widgets** — markdown `TranscriptView` with inline image support and a paste-aware `ChatInput`.

### Why

Until now the Claude chat dock was hard-wired inside the `sciqlop_claude` plugin. Pulling the agent-agnostic bits into core means:

- Future backends (Codex, Gemini, local Ollama, …) can ship as thin adapter plugins without duplicating the tool surface, chat UI, session dropdown, or write-action gating.
- Only one dock appears regardless of how many backend plugins are installed — the user switches with a dropdown, each backend keeps its own conversation state.
- Tools live next to the app, not in every plugin; bug fixes and new tools land in one place.

### Design notes

- `AgentBackend` is a `@runtime_checkable` Protocol — no inheritance required.
- `BackendContext` carries the main window, shared tool list, per-backend tempdir, confirm callback, and `allow_writes` flag.
- Permission gating: the dock owns the approval dialog and passes an async `confirm_cb`; backends call it through `can_use_tool`-style hooks.
- Session resume: the protocol exposes `list_sessions()` / `load_session()` / `resume()` — Claude implements this over the SDK's JSONL session store; backends without sessions just set `supports_sessions = False`.
- `ensure_agent_dock(main_window)` is idempotent — the first plugin that registers a backend creates the dock, later plugins' `register_agent_backend` calls trigger a dropdown refresh.

### Follow-up

The Claude adapter is split off into `sciqlop_claude` (see the matching PR on `SciQLop/sciqlop-plugins`). This PR is a prerequisite for that one.

## Test plan

- [ ] Install with `sciqlop_claude` plugin checked out against this branch
- [ ] Launch SciQLop, open the "Agents" dock
- [ ] Send a text prompt, see streaming response rendered as markdown
- [ ] Ask Claude to `sciqlop_screenshot_panel`; verify the PNG renders inline
- [ ] Paste an image into the input, send, verify Claude receives it
- [ ] Toggle "Allow write actions", verify `exec_python` / `set_time_range` prompt for approval
- [ ] Switch backend dropdown (with a second backend installed) and verify per-backend state is preserved
- [ ] Close and reopen the dock, verify tempdir is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)