### PR TITLE
feat(agents): prompt history, products tree fix, resilient plugin loader

### DIFF
--- a/SciQLop/components/agents/chat/history.py
+++ b/SciQLop/components/agents/chat/history.py
@@ -1,0 +1,67 @@
+"""Prompt history with fuzzy search for the agent chat input."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List
+
+from SciQLop.components.command_palette.backend.fuzzy import fuzzy_score
+
+_DEFAULT_PATH = Path("~/.config/sciqlop/agent_prompt_history.json").expanduser()
+_MAX_ENTRIES = 200
+
+
+class PromptHistory:
+    def __init__(self, path: Path = _DEFAULT_PATH, max_size: int = _MAX_ENTRIES):
+        self._path = path
+        self._max_size = max_size
+        self._entries: list[str] | None = None
+
+    def _load(self) -> list[str]:
+        if self._entries is not None:
+            return self._entries
+        self._entries = []
+        if self._path.exists():
+            try:
+                with open(self._path) as f:
+                    raw = json.load(f)
+                if isinstance(raw, list):
+                    self._entries = [s for s in raw if isinstance(s, str)]
+            except (json.JSONDecodeError, OSError):
+                self._entries = []
+        return self._entries
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._path, "w") as f:
+            json.dump(self._load(), f)
+
+    def add(self, prompt: str) -> None:
+        prompt = prompt.strip()
+        if not prompt:
+            return
+        entries = self._load()
+        # Move to front if already present (dedup)
+        try:
+            entries.remove(prompt)
+        except ValueError:
+            pass
+        entries.insert(0, prompt)
+        if len(entries) > self._max_size:
+            del entries[self._max_size:]
+        self._save()
+
+    def entries(self) -> List[str]:
+        return list(self._load())
+
+    def search(self, query: str, limit: int = 20) -> List[str]:
+        if not query:
+            return self.entries()[:limit]
+        scored = [
+            (fuzzy_score(query, entry), entry)
+            for entry in self._load()
+        ]
+        scored = [(s, e) for s, e in scored if s > 0]
+        scored.sort(key=lambda t: t[0], reverse=True)
+        return [e for _, e in scored[:limit]]

--- a/SciQLop/components/agents/chat/view.py
+++ b/SciQLop/components/agents/chat/view.py
@@ -14,12 +14,24 @@ from PySide6.QtCore import QMimeData, QStringListModel, Qt, QTimer, QUrl
 from PySide6.QtGui import (
     QImage,
     QKeyEvent,
+    QStandardItem,
+    QStandardItemModel,
     QTextCursor,
     QTextDocument,
     QTextDocumentFragment,
     QTextImageFormat,
 )
-from PySide6.QtWidgets import QCompleter, QTextBrowser, QTextEdit
+from PySide6.QtWidgets import (
+    QCompleter,
+    QLineEdit,
+    QListView,
+    QTextBrowser,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .history import PromptHistory
 
 
 @dataclass
@@ -143,7 +155,7 @@ class TranscriptView(QTextBrowser):
 class ChatInput(QTextEdit):
     _DEFAULT_PLACEHOLDER = (
         "Ask about the current SciQLop state… "
-        "(Ctrl+V to paste images, / for commands)"
+        "(Ctrl+V to paste images, / for commands, ↑↓ history, Ctrl+R search)"
     )
 
     def __init__(self, tempdir: Path, parent=None):
@@ -160,6 +172,12 @@ class ChatInput(QTextEdit):
         self._completer.setCompletionMode(QCompleter.CompletionMode.PopupCompletion)
         self._completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
         self._completer.activated.connect(self._insert_completion)
+
+        self._history = PromptHistory()
+        self._history_index = -1
+        self._draft = ""
+
+        self._search_popup: _HistorySearchPopup | None = None
 
     def set_completions(self, words: List[str]) -> None:
         self._completer_model.setStringList(sorted(set(words)))
@@ -185,6 +203,40 @@ class ChatInput(QTextEdit):
         cursor.insertText(completion + " ")
         self.setTextCursor(cursor)
 
+    def _navigate_history(self, direction: int) -> bool:
+        entries = self._history.entries()
+        if not entries:
+            return False
+        if self._history_index == -1:
+            self._draft = self.toPlainText()
+        new_index = self._history_index + direction
+        if new_index < -1:
+            return False
+        if new_index >= len(entries):
+            return False
+        self._history_index = new_index
+        if new_index == -1:
+            self.setPlainText(self._draft)
+        else:
+            self.setPlainText(entries[new_index])
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.setTextCursor(cursor)
+        return True
+
+    def _open_history_search(self) -> None:
+        if self._search_popup is None:
+            self._search_popup = _HistorySearchPopup(self._history, self)
+            self._search_popup.prompt_selected.connect(self._on_history_selected)
+        self._search_popup.show_at(self)
+
+    def _on_history_selected(self, prompt: str) -> None:
+        self.setPlainText(prompt)
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.setTextCursor(cursor)
+        self.setFocus()
+
     def keyPressEvent(self, event: QKeyEvent) -> None:
         popup = self._completer.popup()
         if popup and popup.isVisible():
@@ -198,6 +250,20 @@ class ChatInput(QTextEdit):
             ):
                 event.ignore()
                 return
+
+        # Ctrl+R → fuzzy history search
+        if event.key() == Qt.Key.Key_R and event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            self._open_history_search()
+            return
+
+        # Up/Down → history navigation (only when cursor is on first/last line)
+        if event.key() == Qt.Key.Key_Up and self._cursor_on_first_line():
+            if self._navigate_history(1):
+                return
+        if event.key() == Qt.Key.Key_Down and self._cursor_on_last_line():
+            if self._navigate_history(-1):
+                return
+
         super().keyPressEvent(event)
         token = self._current_slash_token()
         if len(token) >= 1 and self._completer_model.rowCount() > 0:
@@ -211,6 +277,16 @@ class ChatInput(QTextEdit):
         else:
             if popup:
                 popup.hide()
+
+    def _cursor_on_first_line(self) -> bool:
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.StartOfLine)
+        return cursor.atStart()
+
+    def _cursor_on_last_line(self) -> bool:
+        cursor = self.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.EndOfLine)
+        return cursor.atEnd()
 
     def canInsertFromMimeData(self, source: QMimeData) -> bool:
         if source.hasImage() or source.hasUrls():
@@ -257,4 +333,100 @@ class ChatInput(QTextEdit):
         images = list(self._pending_images)
         self._pending_images.clear()
         self.clear()
+        self._history_index = -1
+        self._draft = ""
+        if body:
+            self._history.add(body)
         return body, images
+
+
+class _HistorySearchPopup(QWidget):
+    """Overlay popup for fuzzy-searching prompt history (Ctrl+R)."""
+
+    from PySide6.QtCore import Signal
+    prompt_selected = Signal(str)
+
+    def __init__(self, history: PromptHistory, parent: QWidget):
+        super().__init__(parent, Qt.WindowType.Popup)
+        self._history = history
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(2)
+
+        self._input = QLineEdit(self)
+        self._input.setPlaceholderText("Search history…")
+        self._input.textChanged.connect(self._on_query_changed)
+        self._input.installEventFilter(self)
+        layout.addWidget(self._input)
+
+        self._list = QListView(self)
+        self._model = QStandardItemModel(self)
+        self._list.setModel(self._model)
+        self._list.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self._list.clicked.connect(self._on_item_clicked)
+        layout.addWidget(self._list)
+
+        self.setMinimumWidth(400)
+        self.setMaximumHeight(300)
+
+    def show_at(self, anchor: QWidget) -> None:
+        self._input.clear()
+        self._refresh_results("")
+        pos = anchor.mapToGlobal(anchor.rect().topLeft())
+        pos.setY(pos.y() - self.sizeHint().height() - 4)
+        self.move(pos)
+        self.show()
+        self._input.setFocus()
+
+    def _on_query_changed(self, text: str) -> None:
+        self._refresh_results(text)
+
+    def _refresh_results(self, query: str) -> None:
+        self._model.clear()
+        for entry in self._history.search(query, limit=20):
+            item = QStandardItem(_truncate(entry, 120))
+            item.setData(entry, Qt.ItemDataRole.UserRole)
+            item.setEditable(False)
+            self._model.appendRow(item)
+
+    def _on_item_clicked(self, index) -> None:
+        prompt = index.data(Qt.ItemDataRole.UserRole)
+        if prompt:
+            self.prompt_selected.emit(prompt)
+        self.hide()
+
+    def eventFilter(self, obj, event) -> bool:
+        if obj is self._input and isinstance(event, QKeyEvent):
+            if event.key() == Qt.Key.Key_Escape:
+                self.hide()
+                return True
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                idx = self._list.currentIndex()
+                if not idx.isValid() and self._model.rowCount() > 0:
+                    idx = self._model.index(0, 0)
+                if idx.isValid():
+                    prompt = idx.data(Qt.ItemDataRole.UserRole)
+                    if prompt:
+                        self.prompt_selected.emit(prompt)
+                self.hide()
+                return True
+            if event.key() == Qt.Key.Key_Down:
+                idx = self._list.currentIndex()
+                next_row = (idx.row() + 1) if idx.isValid() else 0
+                if next_row < self._model.rowCount():
+                    self._list.setCurrentIndex(self._model.index(next_row, 0))
+                return True
+            if event.key() == Qt.Key.Key_Up:
+                idx = self._list.currentIndex()
+                if idx.isValid() and idx.row() > 0:
+                    self._list.setCurrentIndex(self._model.index(idx.row() - 1, 0))
+                return True
+        return super().eventFilter(obj, event)
+
+
+def _truncate(text: str, max_len: int) -> str:
+    single_line = text.replace("\n", " ").strip()
+    if len(single_line) <= max_len:
+        return single_line
+    return single_line[:max_len - 1] + "…"

--- a/SciQLop/components/agents/tools/products_tree.py
+++ b/SciQLop/components/agents/tools/products_tree.py
@@ -37,9 +37,24 @@ def _split_path(path: str) -> List[str]:
 
 def _render_root(pm, node_types) -> str:
     root = pm.node([])
-    if root is None:
+    if root is not None:
+        return _render_folder([], root, node_types)
+    # ProductsModel has no explicit root node — enumerate top-level children
+    # via the QAbstractItemModel API (rowCount at invalid parent index).
+    from PySide6.QtCore import QModelIndex
+    count = pm.rowCount(QModelIndex())
+    if count == 0:
         return "# Products tree is empty — no providers loaded."
-    return _render_folder([], root, node_types)
+    names = []
+    for i in range(count):
+        idx = pm.index(i, 0, QModelIndex())
+        names.append(idx.data() or f"<row {i}>")
+    lines = ["# `<root>`", "", f"## Providers ({count})", ""]
+    for name in names:
+        lines.append(f"- 📁 **`{name}`**")
+    lines.append("")
+    lines.append(f"Drill deeper with `sciqlop_products_tree('{names[0]}')`.")
+    return "\n".join(lines)
 
 
 def _render_folder(parts: List[str], node, node_types) -> str:

--- a/SciQLop/components/plugins/backend/loader/loader.py
+++ b/SciQLop/components/plugins/backend/loader/loader.py
@@ -103,10 +103,14 @@ def background_load(plugin, main_window):
 
 
 def list_plugins_as_modules(plugin_path):
+    if not os.path.isdir(plugin_path):
+        return []
     return [f[:-3] for f in os.listdir(plugin_path) if f[-3:] == '.py' and f != '__init__.py']
 
 
 def list_plugins_as_packages(plugin_path):
+    if not os.path.isdir(plugin_path):
+        return []
     return [f for f in os.listdir(plugin_path) if os.path.isdir(f"{plugin_path}/{f}") and not f.startswith(('_', '.'))]
 
 

--- a/tests/test_products_tree.py
+++ b/tests/test_products_tree.py
@@ -1,0 +1,125 @@
+"""Tests for the agent products_tree browser.
+
+The products_tree module lives deep in the agents package, which pulls
+in the full SciQLop app at import time.  We load only the file itself
+with its package set so relative imports resolve to mocks.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_PKG = "SciQLop.components.agents.tools"
+_MOD_NAME = f"{_PKG}.products_tree"
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "SciQLop" / "components" / "agents" / "tools" / "products_tree.py"
+)
+
+
+@pytest.fixture()
+def ptree():
+    """Load products_tree.py in isolation, mocking its dependencies."""
+    # Stub out the parent package and sibling module so relative imports work
+    pkg_stub = MagicMock()
+    text_stub = MagicMock()
+    text_stub.first_line = lambda s: s.split("\n", 1)[0]
+
+    saved = {}
+    for key in (_PKG, f"{_PKG}._text", _MOD_NAME):
+        saved[key] = sys.modules.get(key)
+
+    sys.modules[_PKG] = pkg_stub
+    sys.modules[f"{_PKG}._text"] = text_stub
+
+    spec = importlib.util.spec_from_file_location(
+        _MOD_NAME, _MOD_PATH,
+        submodule_search_locations=[],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = _PKG
+    spec.loader.exec_module(mod)
+
+    yield mod
+
+    # restore
+    for key, val in saved.items():
+        if val is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = val
+
+
+class _FakeNodeTypes:
+    PARAMETER = "PARAMETER"
+
+
+def _make_model(node_result, row_names=None):
+    """Build a mock ProductsModel.
+
+    node_result: what pm.node([]) returns (None to simulate missing root).
+    row_names:   top-level provider names exposed via QAbstractItemModel API.
+    """
+    pm = MagicMock()
+    pm.node.return_value = node_result
+
+    if row_names is None:
+        row_names = []
+
+    pm.rowCount.return_value = len(row_names)
+
+    def _index(row, _col, _parent):
+        idx = MagicMock()
+        idx.data.return_value = row_names[row] if row < len(row_names) else None
+        return idx
+
+    pm.index.side_effect = _index
+    return pm
+
+
+# --- _split_path ---
+
+def test_split_path_empty(ptree):
+    assert ptree._split_path("") == []
+    assert ptree._split_path("  ") == []
+
+
+def test_split_path_double_slash(ptree):
+    assert ptree._split_path("speasy//amda//Parameters") == [
+        "speasy", "amda", "Parameters",
+    ]
+
+
+def test_split_path_single_slash_fallback(ptree):
+    assert ptree._split_path("speasy/amda") == ["speasy", "amda"]
+
+
+# --- _render_root ---
+
+def test_render_root_truly_empty(ptree):
+    """No root node AND no rows → reports empty tree."""
+    pm = _make_model(node_result=None, row_names=[])
+    result = ptree._render_root(pm, _FakeNodeTypes)
+    assert "empty" in result.lower()
+
+
+def test_render_root_no_root_node_but_has_providers(ptree):
+    """Bug reproducer: pm.node([]) is None but providers exist as rows.
+
+    Before the fix, this incorrectly reported 'no providers loaded'.
+    """
+    pm = _make_model(node_result=None, row_names=["speasy"])
+    result = ptree._render_root(pm, _FakeNodeTypes)
+    assert "speasy" in result
+    assert "empty" not in result.lower()
+    assert "no providers" not in result.lower()
+
+
+def test_render_root_no_root_node_multiple_providers(ptree):
+    pm = _make_model(node_result=None, row_names=["speasy", "local"])
+    result = ptree._render_root(pm, _FakeNodeTypes)
+    assert "speasy" in result
+    assert "local" in result
+    assert "Providers (2)" in result

--- a/tests/test_prompt_history.py
+++ b/tests/test_prompt_history.py
@@ -1,0 +1,110 @@
+"""Tests for the agent chat prompt history with fuzzy search."""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load history.py directly to avoid the agents/__init__.py import chain
+_MOD_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "SciQLop" / "components" / "agents" / "chat" / "history.py"
+)
+_PKG = "SciQLop.components.agents.chat"
+_MOD_NAME = f"{_PKG}.history"
+
+
+@pytest.fixture()
+def PromptHistory():
+    spec = importlib.util.spec_from_file_location(_MOD_NAME, _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = _PKG
+    spec.loader.exec_module(mod)
+    return mod.PromptHistory
+
+
+@pytest.fixture()
+def history(tmp_path, PromptHistory):
+    return PromptHistory(path=tmp_path / "history.json", max_size=10)
+
+
+def test_empty_history(history):
+    assert history.entries() == []
+
+
+def test_add_and_retrieve(history):
+    history.add("plot ACE data")
+    assert history.entries() == ["plot ACE data"]
+
+
+def test_most_recent_first(history):
+    history.add("first")
+    history.add("second")
+    assert history.entries() == ["second", "first"]
+
+
+def test_dedup_moves_to_front(history):
+    history.add("alpha")
+    history.add("beta")
+    history.add("alpha")
+    assert history.entries() == ["alpha", "beta"]
+
+
+def test_blank_ignored(history):
+    history.add("")
+    history.add("   ")
+    assert history.entries() == []
+
+
+def test_max_size_enforced(history):
+    for i in range(15):
+        history.add(f"prompt {i}")
+    assert len(history.entries()) == 10
+    assert history.entries()[0] == "prompt 14"
+
+
+def test_persists_to_disk(tmp_path, PromptHistory):
+    path = tmp_path / "history.json"
+    h1 = PromptHistory(path=path)
+    h1.add("saved")
+
+    h2 = PromptHistory(path=path)
+    assert h2.entries() == ["saved"]
+
+
+def test_search_empty_query_returns_all(history):
+    history.add("alpha")
+    history.add("beta")
+    results = history.search("")
+    assert results == ["beta", "alpha"]
+
+
+def test_search_exact_match(history):
+    history.add("plot ACE magnetic field")
+    history.add("set time range")
+    history.add("screenshot panel")
+    results = history.search("ACE")
+    assert "plot ACE magnetic field" in results
+    assert "set time range" not in results
+
+
+def test_search_fuzzy(history):
+    history.add("plot ACE magnetic field")
+    history.add("plot MMS ion data")
+    history.add("screenshot panel")
+    results = history.search("plt ACE")
+    assert results[0] == "plot ACE magnetic field"
+
+
+def test_search_limit(history):
+    for i in range(10):
+        history.add(f"prompt {i}")
+    results = history.search("", limit=3)
+    assert len(results) == 3
+
+
+def test_corrupt_file_handled(tmp_path, PromptHistory):
+    path = tmp_path / "history.json"
+    path.write_text("not valid json{{{")
+    h = PromptHistory(path=path)
+    assert h.entries() == []


### PR DESCRIPTION
## Summary

- **Products tree fix**: `ProductsModel.node([])` returns `None` (no explicit root node), but providers like "speasy" exist as children. Fall back to `QAbstractItemModel` `rowCount`/`index` API to enumerate them — fixes the agent tool always reporting "no providers loaded".
- **Prompt history**: `PromptHistory` with JSON persistence, dedup, and fuzzy search (reuses the command palette's `fuzzy_score`). Up/Down arrows navigate history, Ctrl+R opens a fuzzy search popup.
- **Resilient plugin loader**: `list_plugins_as_modules`/`list_plugins_as_packages` now guard against missing directories instead of crashing at startup.

## Test plan

- [ ] `uv run pytest tests/test_products_tree.py tests/test_prompt_history.py` — 18 tests pass
- [ ] Start SciQLop, open agent dock, send a few prompts, verify Up/Down cycles through them
- [ ] Press Ctrl+R in the input, type a fuzzy query, verify matching prompts appear
- [ ] Verify `sciqlop_products_tree("")` returns providers (not "empty") when speasy is loaded
- [ ] Remove a configured plugin folder, verify SciQLop starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)