### PR TITLE
fix(windows): clean payload on upgrade and invalidate stale workspace venvs

### DIFF
--- a/SciQLop/components/startup/startup_window.py
+++ b/SciQLop/components/startup/startup_window.py
@@ -150,7 +150,17 @@ class StartupWindow(QWidget):
             "  padding: 6px 16px; }"
             "QPushButton:hover { background: #555; }"
         )
+        # Splash-screen windows have no taskbar entry and don't accept focus,
+        # so a hidden splash showing an error is invisible to users.  Switch
+        # to a regular top-level window with a title and force it to the
+        # front so failed launches can't disappear silently.
+        self.hide()
+        self.setWindowFlags(Qt.Window | Qt.WindowStaysOnTopHint)
+        self.setWindowTitle("SciQLop — startup failed")
         self.center_on_screen()
+        self.show()
+        self.raise_()
+        self.activateWindow()
         self.update()
 
     def _copy_error(self) -> None:

--- a/SciQLop/components/workspaces/backend/workspace_venv.py
+++ b/SciQLop/components/workspaces/backend/workspace_venv.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 from collections.abc import Callable
 from pathlib import Path
 
@@ -13,6 +15,32 @@ from SciQLop.core.common.python import get_python
 from SciQLop.components.workspaces.backend.uv import uv_command
 
 _WINDOWS = os.name == "nt"
+_SYSTEM_FINGERPRINT_FILENAME = ".sciqlop_system_fingerprint"
+
+
+def _system_packages_fingerprint() -> str:
+    """Hash the dist-info directory names in the bundled Python's site-packages.
+
+    A workspace venv created with --system-site-packages inherits whatever is
+    installed in the system layer.  When a SciQLop upgrade replaces the
+    bundled PySide6 / SciQLopPlots binaries underneath an existing venv, the
+    venv's own pinned copies and the system's new copies collide at import
+    time (different ABIs).  This fingerprint changes whenever any package is
+    added, removed, or re-versioned in the system layer, so the venv can be
+    rebuilt against the new stack.
+    """
+    purelib = Path(sysconfig.get_paths()["purelib"])
+    if not purelib.is_dir():
+        return ""
+    names = sorted(
+        p.name for p in purelib.iterdir()
+        if p.is_dir() and p.suffix == ".dist-info"
+    )
+    h = hashlib.sha256()
+    for name in names:
+        h.update(name.encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
 
 
 def _run_uv(cmd: list[str], on_output: Callable[[str], None] | None = None, **kwargs) -> None:
@@ -82,6 +110,22 @@ class WorkspaceVenv:
                 result[key.strip()] = value.strip()
         return result
 
+    @property
+    def _fingerprint_path(self) -> Path:
+        return self._venv_dir / _SYSTEM_FINGERPRINT_FILENAME
+
+    def _read_fingerprint(self) -> str:
+        try:
+            return self._fingerprint_path.read_text().strip()
+        except OSError:
+            return ""
+
+    def _write_fingerprint(self) -> None:
+        try:
+            self._fingerprint_path.write_text(_system_packages_fingerprint())
+        except OSError:
+            pass
+
     def _needs_recreate(self) -> bool:
         if not self.exists:
             return True
@@ -97,6 +141,8 @@ class WorkspaceVenv:
             return True
         if python.is_symlink() and str(python.resolve()) != str(Path(get_python()).resolve()):
             return True
+        if self._read_fingerprint() != _system_packages_fingerprint():
+            return True
         return False
 
     def ensure(self, on_output: Callable[[str], None] | None = None) -> None:
@@ -105,3 +151,4 @@ class WorkspaceVenv:
             if self._venv_dir.exists():
                 shutil.rmtree(self._venv_dir)
             self.create(on_output=on_output)
+            self._write_fingerprint()

--- a/SciQLop/components/workspaces/backend/workspace_venv.py
+++ b/SciQLop/components/workspaces/backend/workspace_venv.py
@@ -120,11 +120,22 @@ class WorkspaceVenv:
         except OSError:
             return ""
 
-    def _write_fingerprint(self) -> None:
+    def _write_fingerprint(self, on_output: Callable[[str], None] | None = None) -> None:
         try:
             self._fingerprint_path.write_text(_system_packages_fingerprint())
-        except OSError:
-            pass
+        except OSError as exc:
+            # If we can't persist the marker, _needs_recreate() will keep
+            # returning True on every launch and recreate the venv in a loop.
+            # Surface the error so the user can fix the underlying problem
+            # (read-only workspace, permissions, disk full, ...).
+            msg = (
+                f"Warning: failed to write venv fingerprint at "
+                f"{self._fingerprint_path}: {exc}.  The workspace venv may "
+                "be recreated on every launch until this is resolved."
+            )
+            print(msg, file=sys.stderr)
+            if on_output is not None:
+                on_output(msg)
 
     def _needs_recreate(self) -> bool:
         if not self.exists:
@@ -151,4 +162,4 @@ class WorkspaceVenv:
             if self._venv_dir.exists():
                 shutil.rmtree(self._venv_dir)
             self.create(on_output=on_output)
-            self._write_fingerprint()
+            self._write_fingerprint(on_output=on_output)

--- a/SciQLop/sciqlop_launcher.py
+++ b/SciQLop/sciqlop_launcher.py
@@ -105,6 +105,19 @@ def check_xcb_cursor() -> str | None:
         )
 
 
+def _last_launch_log_path() -> Path:
+    """Stable on-disk log location for the most recent SciQLop subprocess.
+
+    The bundled Windows launcher (``launcher.c``) spawns the Python entry
+    point with ``CREATE_NO_WINDOW``, so any output written to stdout/stderr
+    is otherwise lost.  Tee the subprocess output here so users (and bug
+    reports) have something to point to when SciQLop fails to start.
+    """
+    from platformdirs import user_data_dir
+    log_dir = Path(user_data_dir(appname="sciqlop", appauthor="LPP", ensure_exists=True))
+    return log_dir / "last-launch.log"
+
+
 def _run_with_startup_window(workspace_name: str | None, sciqlop_file: str | None) -> tuple[int, Path | None]:
     from PySide6.QtCore import QEventLoop, QTimer
     from PySide6.QtWidgets import QApplication
@@ -170,21 +183,33 @@ def _run_with_startup_window(workspace_name: str | None, sciqlop_file: str | Non
     env["SPEASY_SKIP_INIT_PROVIDERS"] = "1"
     env[READY_FILE_ENV] = str(ready_file)
 
+    log_path = _last_launch_log_path()
+    log_file = open(log_path, "w", encoding="utf-8", errors="replace")
+    log_file.write(f"$ {python_path} -m SciQLop.sciqlop_app\n")
+    log_file.flush()
+
     proc = subprocess.Popen(
         [str(python_path), "-m", "SciQLop.sciqlop_app"],
         env=env,
+        stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
     )
-    # Drain stderr in a background thread to prevent pipe buffer deadlock
     import threading
     stderr_lines: list[str] = []
 
-    def _drain_stderr():
-        for line in proc.stderr:
-            stderr_lines.append(line)
+    def _drain(stream, label: str, capture: list[str] | None):
+        for line in stream:
+            if capture is not None:
+                capture.append(line)
+            try:
+                log_file.write(f"[{label}] {line}")
+                log_file.flush()
+            except Exception:
+                pass
 
-    threading.Thread(target=_drain_stderr, daemon=True).start()
+    threading.Thread(target=_drain, args=(proc.stdout, "out", None), daemon=True).start()
+    threading.Thread(target=_drain, args=(proc.stderr, "err", stderr_lines), daemon=True).start()
 
     def check_ready():
         if ready_file.exists():
@@ -199,6 +224,7 @@ def _run_with_startup_window(workspace_name: str | None, sciqlop_file: str | Non
             timer.stop()
             window.show_error(
                 f"SciQLop process exited with code {proc.returncode}.\n\n"
+                f"Full output: {log_path}\n\n"
                 f"{''.join(stderr_lines)}"
             )
 
@@ -209,6 +235,7 @@ def _run_with_startup_window(workspace_name: str | None, sciqlop_file: str | Non
     app.exec()
     timer.stop()
 
+    log_file.close()
     shutil.rmtree(ready_dir, ignore_errors=True)
 
     if proc.poll() is None:

--- a/SciQLop/sciqlop_launcher.py
+++ b/SciQLop/sciqlop_launcher.py
@@ -184,63 +184,98 @@ def _run_with_startup_window(workspace_name: str | None, sciqlop_file: str | Non
     env[READY_FILE_ENV] = str(ready_file)
 
     log_path = _last_launch_log_path()
-    log_file = open(log_path, "w", encoding="utf-8", errors="replace")
-    log_file.write(f"$ {python_path} -m SciQLop.sciqlop_app\n")
-    log_file.flush()
+    try:
+        log_file = open(log_path, "w", encoding="utf-8", errors="replace")
+    except OSError:
+        # If we can't open the log file, fall back to a sink that drops writes
+        # rather than crash the launcher.
+        import io
+        log_file = io.StringIO()
+        log_path = None
+    proc: subprocess.Popen | None = None
+    try:
+        log_file.write(f"$ {python_path} -m SciQLop.sciqlop_app\n")
+        log_file.flush()
 
-    proc = subprocess.Popen(
-        [str(python_path), "-m", "SciQLop.sciqlop_app"],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    import threading
-    stderr_lines: list[str] = []
+        proc = subprocess.Popen(
+            [str(python_path), "-m", "SciQLop.sciqlop_app"],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
 
-    def _drain(stream, label: str, capture: list[str] | None):
-        for line in stream:
-            if capture is not None:
-                capture.append(line)
-            try:
-                log_file.write(f"[{label}] {line}")
-                log_file.flush()
-            except Exception:
-                pass
+        import threading
+        stderr_lines: list[str] = []
+        drain_threads: list[threading.Thread] = []
 
-    threading.Thread(target=_drain, args=(proc.stdout, "out", None), daemon=True).start()
-    threading.Thread(target=_drain, args=(proc.stderr, "err", stderr_lines), daemon=True).start()
+        def _drain(stream, label: str, capture: list[str] | None):
+            for line in stream:
+                if capture is not None:
+                    capture.append(line)
+                try:
+                    log_file.write(f"[{label}] {line}")
+                    log_file.flush()
+                except Exception:
+                    pass
 
-    def check_ready():
-        if ready_file.exists():
-            window.close()
-            app.processEvents()
-            try:
-                ready_file.unlink()
-            except OSError:
-                pass
-            app.quit()
-        elif proc.poll() is not None:
-            timer.stop()
-            window.show_error(
-                f"SciQLop process exited with code {proc.returncode}.\n\n"
-                f"Full output: {log_path}\n\n"
-                f"{''.join(stderr_lines)}"
-            )
+        for stream, label, capture in (
+            (proc.stdout, "out", None),
+            (proc.stderr, "err", stderr_lines),
+        ):
+            t = threading.Thread(target=_drain, args=(stream, label, capture), daemon=True)
+            t.start()
+            drain_threads.append(t)
 
-    timer = QTimer()
-    timer.timeout.connect(check_ready)
-    timer.start(100)
+        def check_ready():
+            if ready_file.exists():
+                window.close()
+                app.processEvents()
+                try:
+                    ready_file.unlink()
+                except OSError:
+                    pass
+                app.quit()
+            elif proc.poll() is not None:
+                timer.stop()
+                window.show_error(
+                    f"SciQLop process exited with code {proc.returncode}.\n\n"
+                    f"Full output: {log_path}\n\n"
+                    f"{''.join(stderr_lines)}"
+                )
 
-    app.exec()
-    timer.stop()
+        timer = QTimer()
+        timer.timeout.connect(check_ready)
+        timer.start(100)
 
-    log_file.close()
-    shutil.rmtree(ready_dir, ignore_errors=True)
+        app.exec()
+        timer.stop()
 
-    if proc.poll() is None:
-        return proc.wait(), workspace_dir
-    return proc.returncode, workspace_dir
+        # Wait for the subprocess to exit before closing the log so that any
+        # output produced after the splash window closed (i.e. for the rest of
+        # the SciQLop session) still lands in last-launch.log.
+        exit_code = proc.wait() if proc.poll() is None else proc.returncode
+        for t in drain_threads:
+            t.join(timeout=2.0)
+        return exit_code, workspace_dir
+    except Exception:
+        # If anything in the subprocess setup raised, surface it to the user
+        # rather than letting the launcher crash silently.
+        import traceback
+        try:
+            window.show_error(traceback.format_exc())
+            app.exec()
+        except Exception:
+            pass
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+        return 1, workspace_dir
+    finally:
+        try:
+            log_file.close()
+        except Exception:
+            pass
+        shutil.rmtree(ready_dir, ignore_errors=True)
 
 
 def _prepare_workspace_dev(workspace_dir: Path, on_output=None) -> None:

--- a/scripts/windows/installer.iss
+++ b/scripts/windows/installer.iss
@@ -28,6 +28,17 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
+; Wipe the previous payload before extracting the new bundle.  Without this,
+; Inno Setup overlays files in {app} and never deletes ones that have moved
+; to a different name in the new bundle (e.g. pyside6-6.10.2.dist-info →
+; pyside6-6.11.0.dist-info), leaving two parallel installs side-by-side and
+; producing ABI mismatches at import time.  User data lives in
+; %LOCALAPPDATA%\LPP\sciqlop and is untouched.
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\python"
+Type: filesandordirs; Name: "{app}\node"
+Type: filesandordirs; Name: "{app}\uv"
+
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 

--- a/scripts/windows/installer.iss
+++ b/scripts/windows/installer.iss
@@ -21,6 +21,11 @@ ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 SetupIconFile={#SourceDir}\python\Lib\site-packages\SciQLop\resources\icons\SciQLop.ico
 UninstallDisplayIcon={app}\python\Lib\site-packages\SciQLop\resources\icons\SciQLop.ico
+; Force-close any SciQLop / bundled python.exe using files in {app} via the
+; Windows Restart Manager before [InstallDelete] and [Files] run.  Without
+; this, an upgrade install over a running SciQLop fails with "access denied"
+; on python.exe / SciQLop.exe.
+CloseApplications=force
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -49,3 +54,12 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilen
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch SciQLop"; Flags: nowait postinstall skipifsilent
+
+; Inno Setup only tracks files extracted by [Files], so __pycache__ and any
+; other runtime-generated artifacts inside {app}\python are left behind on
+; uninstall.  Wipe the whole bundled-runtime tree to guarantee a clean
+; uninstall.  User data in %LOCALAPPDATA%\LPP\sciqlop is untouched.
+[UninstallDelete]
+Type: filesandordirs; Name: "{app}\python"
+Type: filesandordirs; Name: "{app}\node"
+Type: filesandordirs; Name: "{app}\uv"

--- a/scripts/windows/online_installer.iss
+++ b/scripts/windows/online_installer.iss
@@ -28,6 +28,16 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
+; Wipe the previous payload before install.ps1 runs uv pip install.  Without
+; this, re-running the installer leaves stale dist-info dirs from the older
+; versions side-by-side with the new ones (uv does not always evict them),
+; producing ABI mismatches at runtime.  User data lives in
+; %LOCALAPPDATA%\LPP\sciqlop and is untouched.
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\python"
+Type: filesandordirs; Name: "{app}\node"
+Type: filesandordirs; Name: "{app}\uv"
+
 [Files]
 Source: "{#LauncherExe}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#ScriptDir}\install.ps1"; DestDir: "{tmp}"; Flags: deleteafterinstall

--- a/scripts/windows/online_installer.iss
+++ b/scripts/windows/online_installer.iss
@@ -21,6 +21,9 @@ ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 SetupIconFile={#ScriptDir}\..\..\SciQLop\resources\icons\SciQLop.ico
 UninstallDisplayIcon={app}\python\Lib\site-packages\SciQLop\resources\icons\SciQLop.ico
+; Force-close any SciQLop / bundled python.exe using files in {app} via the
+; Windows Restart Manager before [InstallDelete] and install.ps1 run.
+CloseApplications=force
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/tests/test_workspace_venv.py
+++ b/tests/test_workspace_venv.py
@@ -142,12 +142,38 @@ class TestEnsure:
 
     @patch.object(WorkspaceVenv, "create")
     def test_skips_create_when_venv_exists(self, mock_create, venv, workspace_dir):
+        from SciQLop.components.workspaces.backend.workspace_venv import (
+            _system_packages_fingerprint,
+            _SYSTEM_FINGERPRINT_FILENAME,
+        )
+        # Use the venv's own platform-aware python_path so this works on
+        # both POSIX (.venv/bin/python) and Windows (.venv/Scripts/python.exe).
         venv_dir = workspace_dir / ".venv"
-        python_path = venv_dir / "bin" / "python"
+        python_path = venv.python_path
         python_path.parent.mkdir(parents=True)
         python_path.touch()
         version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         (venv_dir / "pyvenv.cfg").write_text(f"version_info = {version}\n")
+        (venv_dir / _SYSTEM_FINGERPRINT_FILENAME).write_text(_system_packages_fingerprint())
 
         venv.ensure()
         mock_create.assert_not_called()
+
+    @patch.object(WorkspaceVenv, "create")
+    def test_recreates_when_system_fingerprint_changed(self, mock_create, venv, workspace_dir):
+        from SciQLop.components.workspaces.backend.workspace_venv import (
+            _SYSTEM_FINGERPRINT_FILENAME,
+        )
+        venv_dir = workspace_dir / ".venv"
+        python_path = venv.python_path
+        python_path.parent.mkdir(parents=True)
+        python_path.touch()
+        version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        (venv_dir / "pyvenv.cfg").write_text(f"version_info = {version}\n")
+        # Stale fingerprint: simulates a SciQLop upgrade adding/removing
+        # packages in the bundled Python's site-packages after this venv
+        # was created.
+        (venv_dir / _SYSTEM_FINGERPRINT_FILENAME).write_text("stale-hash-from-previous-version")
+
+        venv.ensure()
+        mock_create.assert_called_once()

--- a/tests/test_workspace_venv.py
+++ b/tests/test_workspace_venv.py
@@ -22,7 +22,11 @@ def venv(workspace_dir):
 
 class TestPythonPath:
     def test_returns_correct_path(self, venv, workspace_dir):
-        assert venv.python_path == workspace_dir / ".venv" / "bin" / "python"
+        if sys.platform == "win32":
+            expected = workspace_dir / ".venv" / "Scripts" / "python.exe"
+        else:
+            expected = workspace_dir / ".venv" / "bin" / "python"
+        assert venv.python_path == expected
 
 
 class TestExists:
@@ -34,7 +38,7 @@ class TestExists:
         assert venv.exists is False
 
     def test_true_when_venv_and_python_exist(self, venv, workspace_dir):
-        python_path = workspace_dir / ".venv" / "bin" / "python"
+        python_path = venv.python_path
         python_path.parent.mkdir(parents=True)
         python_path.touch()
         assert venv.exists is True


### PR DESCRIPTION
## Summary
Re-running the Windows installer over an existing install left two parallel sets of `*.dist-info` directories (PySide6 6.10.2 + 6.11.0, SciQLopPlots 0.21.0 + 0.24.0, etc.) in `{app}\python\Lib\site-packages`, because Inno Setup''s `[Files]` section overlays files but never removes ones that have moved to a new name. The overlay produced ABI mismatches at `SciQLopPlotsBindings.pyd` load time and a silent failure (the bundled `launcher.c` uses `CREATE_NO_WINDOW`, so users saw no error).

The same upgrade also leaves any pre-existing workspace `.venv` referencing the old PySide6/SciQLopPlots ABI; with `--system-site-packages = true`, that venv shadows the new system stack and breaks at import time even on a clean reinstall.

## Changes
- **`installer.iss` / `online_installer.iss`** — add `[InstallDelete]` to wipe `{app}\python`, `\node`, `\uv` before extracting/downloading the new payload. User data in `%LOCALAPPDATA%\LPP\sciqlop` is untouched.
- **`WorkspaceVenv`** — stamp a sha256 fingerprint of the bundled Python''s `*.dist-info` directory names into `.venv\.sciqlop_system_fingerprint` at create time, and force a venv rebuild from `_needs_recreate()` when the fingerprint differs. A workspace `.venv` from before a SciQLop upgrade is now regenerated against the new system stack instead of silently breaking.
- **`sciqlop_launcher.py`** — tee subprocess `stdout` + `stderr` to `%LOCALAPPDATA%\LPP\sciqlop\last-launch.log` and surface the path in the error window. With `CREATE_NO_WINDOW` there was previously no way to see what failed.
- **`StartupWindow.show_error()`** — switch from splash flags (no taskbar entry, no focus) to `Qt.Window | WindowStaysOnTopHint`, set a real title, then `raise_()` + `activateWindow()`. Failed launches can no longer hide behind other windows.
- **Tests** — `test_skips_create_when_venv_exists` made cross-platform (was Linux-only), and a new `test_recreates_when_system_fingerprint_changed` covers the upgrade path.

## How it was diagnosed
Running the bundled Python directly against `SciQLop.sciqlop_app` produced:
```
ImportError: DLL load failed while importing SciQLopPlotsBindings:
The specified procedure could not be found.
```
`importlib.metadata` reported `PySide6 6.10.2` while `PySide6.__version__` reported `6.11.0`; both `.dist-info` dirs were present side-by-side in the system site-packages, with the actual binaries from the newer install. The workspace `.venv` had its own pinned 6.10.2 copy on top, producing the ABI mismatch.

## Test plan
- [x] `pytest tests/test_workspace_venv.py::TestEnsure` — 3 passed (including the new fingerprint-mismatch test)
- [ ] Build the offline installer on CI, install over an older SciQLop install, confirm only one `*.dist-info` per package remains in `{app}\python\Lib\site-packages` after upgrade
- [ ] Verify a workspace `.venv` from a previous version is rebuilt automatically on first launch after upgrade (look for the fingerprint marker file in `.venv\.sciqlop_system_fingerprint`)
- [ ] Force a startup failure (e.g. delete a binding `.pyd`) and confirm the error window appears in the taskbar with the log path visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)