### PR TITLE
Windows MSIX: pass WACK, fix local-build correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ documentation/*
 *.swp
 .serena/
 .superpowers/
+.local-msix-build.ps1
+.local-wack-run.ps1
+launcher.obj
+launcher.res

--- a/scripts/windows/SciQLop.exe.manifest
+++ b/scripts/windows/SciQLop.exe.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor,System</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $SciQLopRoot = Resolve-Path "$ScriptDir\..\.."
-$Dist = "D:\dist"
+# CI uses D:\ (large scratch drive on Azure runners). Local dev overrides via $env:SCIQLOP_DIST_DIR.
+$Dist = if ($env:SCIQLOP_DIST_DIR) { $env:SCIQLOP_DIST_DIR } else { "D:\dist" }
 $PackageDir = "$Dist\S"
 
 $PythonVersion = "3.14"

--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -113,7 +113,11 @@ Move-Item "$Dist\node-v$NodeVersion-win-x64" "$PackageDir\node"
 ########################################
 
 Write-Host "Compiling launcher..."
-& cl /nologo /O2 /Fe:"$PackageDir\SciQLop.exe" "$ScriptDir\launcher.c" `
+# Compile the resource (DPI-awareness + supportedOS manifest embedded as RT_MANIFEST id 1).
+# Without this, WACK's DPIAwarenessValidation flags the launcher as DPI-unaware.
+& rc /nologo /fo "$ScriptDir\launcher.res" "$ScriptDir\launcher.rc"
+if ($LASTEXITCODE -ne 0) { throw "rc.exe failed compiling launcher.rc" }
+& cl /nologo /O2 /Fe:"$PackageDir\SciQLop.exe" "$ScriptDir\launcher.c" "$ScriptDir\launcher.res" `
     /link user32.lib kernel32.lib /SUBSYSTEM:WINDOWS
 
 ########################################
@@ -136,6 +140,30 @@ Get-ChildItem -Path $PackageDir -Recurse |
 # Remove Unix artifacts that trip the Windows Store pre-processing scanner (0x800700C1)
 Get-ChildItem -Path $PackageDir -Recurse -Include *.a,*.o,*.so,*.dylib |
     Remove-Item -Force
+
+# Strip test-data archives flagged by WACK Package Sanity > Archive files usage.
+# These are unit-test fixtures, not runtime data. Keep dateutil-zoneinfo.tar.gz
+# (loaded by dateutil.tz.gettz at runtime).
+$ArchiveStripRoots = @(
+    "$PackageDir\python\Lib\site-packages\astropy",
+    "$PackageDir\python\Lib\site-packages\matplotlib\mpl-data\sample_data"
+)
+foreach ($root in $ArchiveStripRoots) {
+    if (-not (Test-Path $root)) { continue }
+    Get-ChildItem -Path $root -Recurse -File -Include *.gz,*.bz2,*.Z -EA SilentlyContinue |
+        Where-Object {
+            $_.FullName -notmatch '\\dateutil\\zoneinfo\\' -and
+            (
+                $_.FullName -match '\\tests\\data\\' -or
+                $_.FullName -match '\\sample_data\\' -or
+                $_.FullName -match '\\io\\votable\\validator\\data\\'
+            )
+        } |
+        ForEach-Object {
+            Write-Host "Removing test-data archive: $($_.FullName)"
+            Remove-Item -LiteralPath $_.FullName -Force
+        }
+}
 
 # Strip astroquery.jplspec and astroquery.linelists — both ship plain-text data
 # files with a .cat extension (catdir.cat, partfunc.cat) which collide with

--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -69,7 +69,13 @@ if ($ExternallyManaged) { Remove-Item $ExternallyManaged.FullName -Force }
 ########################################
 
 Write-Host "Installing SciQLop..."
-& $UvBin pip install --system --python $PythonBin --link-mode=copy --reinstall --no-cache "$SciQLopRoot\"
+# NB: pass $SciQLopRoot bare. Quoting with a trailing backslash ("$Path\") trips
+# PowerShell's native-arg escaping when $Path contains spaces — the resulting
+# command line ends with \" which uv interprets as an escaped quote and the
+# install fails with "filename, directory name, or volume label syntax is
+# incorrect". CI paths have no spaces so this only bites local dev.
+& $UvBin pip install --system --python $PythonBin --link-mode=copy --reinstall --no-cache $SciQLopRoot
+if ($LASTEXITCODE -ne 0) { throw "uv pip install (SciQLop root) failed with exit $LASTEXITCODE" }
 
 ########################################
 # Plugin dependencies
@@ -80,6 +86,7 @@ $PluginDeps = ($PluginDepsRaw -join " ") -split '\s+' | Where-Object { $_ }
 if ($PluginDeps) {
     Write-Host "Installing plugin dependencies: $PluginDeps"
     & $UvBin pip install --system --python $PythonBin --link-mode=copy @PluginDeps
+    if ($LASTEXITCODE -ne 0) { throw "uv pip install (plugin deps) failed with exit $LASTEXITCODE" }
 }
 
 ########################################
@@ -87,6 +94,7 @@ if ($PluginDeps) {
 ########################################
 
 & $UvBin pip install --system --python $PythonBin --link-mode=copy certifi
+if ($LASTEXITCODE -ne 0) { throw "uv pip install (certifi) failed with exit $LASTEXITCODE" }
 
 ########################################
 # Dev speasy override (non-release only)
@@ -94,6 +102,7 @@ if ($PluginDeps) {
 
 if (-not $env:RELEASE) {
     & $UvBin pip install --system --python $PythonBin --link-mode=copy --upgrade "git+https://github.com/SciQLop/speasy"
+    if ($LASTEXITCODE -ne 0) { throw "uv pip install (speasy dev override) failed with exit $LASTEXITCODE" }
 }
 
 ########################################

--- a/scripts/windows/launcher.rc
+++ b/scripts/windows/launcher.rc
@@ -1,0 +1,3 @@
+#include <winuser.h>
+
+1 RT_MANIFEST "SciQLop.exe.manifest"

--- a/scripts/windows/make_installer.ps1
+++ b/scripts/windows/make_installer.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $SciQLopRoot = Resolve-Path "$ScriptDir\..\.."
-$Dist = "D:\dist"
+# CI uses D:\ (large scratch drive on Azure runners). Local dev overrides via $env:SCIQLOP_DIST_DIR.
+$Dist = if ($env:SCIQLOP_DIST_DIR) { $env:SCIQLOP_DIST_DIR } else { "D:\dist" }
 $PackageDir = "$Dist\S"
 $RepoDist = "$SciQLopRoot\dist"
 

--- a/scripts/windows/make_msix.ps1
+++ b/scripts/windows/make_msix.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $SciQLopRoot = Resolve-Path "$ScriptDir\..\.."
-$Dist = "D:\dist"
+# CI uses D:\ (large scratch drive on Azure runners). Local dev overrides via $env:SCIQLOP_DIST_DIR.
+$Dist = if ($env:SCIQLOP_DIST_DIR) { $env:SCIQLOP_DIST_DIR } else { "D:\dist" }
 $PackageDir = "$Dist\S"
 
 # Run shared bundling


### PR DESCRIPTION
## Summary

Three independent Windows-build fixes, in dependency order:

1. **`chore(windows): honor SCIQLOP_DIST_DIR`** — `bundle.ps1` / `make_msix.ps1` / `make_installer.ps1` hardcode `D:\dist` (Azure runner scratch drive). Local dev machines rarely have `D:\`, so the scripts are unusable outside CI. Honors `$env:SCIQLOP_DIST_DIR` with `D:\dist` as the default — CI behavior unchanged.

2. **`fix(msix): embed DPI-awareness manifest + strip test-data archives`** — fixes the only non-optional WACK finding plus shrinks the package:
   - **DPIAwarenessValidation (WARNING)**: launcher PE had no embedded application manifest, so WACK statically classified the app as DPI-unaware (Qt6 sets it at runtime, but WACK only reads the manifest). Adds `launcher.rc` + `SciQLop.exe.manifest` with PerMonitorV2 + supportedOS GUIDs for Win10/11 + UTF-8 ACP. `bundle.ps1` compile step now invokes `rc.exe` then links the `.res` into the launcher.
   - **Archive files usage (FAIL, optional)**: 23 test-fixture archives under `astropy/io/*/tests/data`, `astropy/utils/tests/data`, `astropy/wcs/tests/data`, `astropy/io/votable/validator/data/urls`, and `matplotlib/mpl-data/sample_data` shipped because the existing tests-dir strip carves out astropy entirely. Adds a targeted strip that explicitly preserves `dateutil-zoneinfo.tar.gz` (loaded at runtime).

3. **`fix(windows): SciQLop install silently fails when repo path has spaces`** — root-cause for what looked like a totally unrelated `ModuleNotFoundError: No module named 'SciQLop'` at MSIX launch. `bundle.ps1` passed `"$SciQLopRoot\"` (quoted, trailing backslash) to uv. When the path has spaces, PowerShell auto-quotes the arg, and the `\"` at the end is interpreted by Microsoft's command-line parser (uv via Rust `std::env::args`) as an escaped quote — uv sees a stray `"` in the path and bails out with `os error 123`. Because `$LASTEXITCODE` wasn't checked, `bundle.ps1` carried on and produced an MSIX missing the SciQLop dist-info. CI doesn't reproduce because the runner path has no spaces. Fix: drop the trailing-backslash + quote, and add `$LASTEXITCODE` throws after every `uv pip install`.

## Verification

Built locally on Windows 11 (path with spaces), ran WACK against the resulting MSIX, registered and launched the package end-to-end:

- WACK: **OVERALL_RESULT = PASS** (was WARNING). DPIAwarenessValidation now PASS with 0 messages.
- 3 remaining WACK FAILs are all `OPTIONAL=TRUE` UWP-only tests (`Install signed driver and executable files`, `Blocked executables`, residual `Archive files usage` for `dateutil-zoneinfo.tar.gz`) — exempted for Centennial / runFullTrust apps. Store re-signs uploads, and full-trust apps are explicitly allowed to call `CreateProcess`/`ShellExecute`.
- Registered via `Add-AppxPackage -Register` (Developer Mode), launched via AUMID through `SciQLop.exe` → bundled `python.exe` → workspace bootstrap (`uv.exe`) — app starts up cleanly.

## Cross-platform safety

Every changed file is inside `scripts/windows/` or `.gitignore`. `scripts/macos/` and `scripts/appimage/` don't reference any of the changed files. Linux and macOS builds are mechanically unaffected.

## CI safety

- `SCIQLOP_DIST_DIR` defaults to `D:\dist` when unset → identical CI behavior.
- Bare-vs-quoted `$SciQLopRoot` is identical for the CI runner path (no spaces) — bug only manifested locally.
- `rc.exe` is already on PATH in CI via the existing `ilammy/msvc-dev-cmd` action.

## Test plan

- [x] Local Windows build with path containing spaces succeeds (was silently broken)
- [x] WACK OVERALL_RESULT = PASS on the resulting MSIX
- [x] `Add-AppxPackage -Register` succeeds
- [x] Packaged app launches via AUMID, Qt main window opens
- [ ] CI Windows build still passes (please verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)